### PR TITLE
Threadsafe io python

### DIFF
--- a/src/mlpack/bindings/R/R_option.hpp
+++ b/src/mlpack/bindings/R/R_option.hpp
@@ -70,12 +70,6 @@ class ROption
     data.required = required;
     data.input = input;
     data.loaded = false;
-
-    // Only "verbose" will be persistent.
-    if (identifier == "verbose")
-      data.persistent = true;
-    else
-      data.persistent = false;
     data.cppType = cppName;
 
     // Every parameter we'll get from R will have the correct type.

--- a/src/mlpack/bindings/R/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/R/print_doc_functions_impl.hpp
@@ -289,8 +289,7 @@ inline std::string ProgramCall(const std::string& programName)
   bool first = true;
   for (auto it = parameters.begin(); it != parameters.end(); ++it)
   {
-    if (!it->second.input || (it->second.persistent &&
-        it->second.name != "verbose"))
+    if (!it->second.input)
       continue;
 
     if (!first)

--- a/src/mlpack/bindings/cli/cli_option.hpp
+++ b/src/mlpack/bindings/cli/cli_option.hpp
@@ -88,7 +88,6 @@ class CLIOption
     data.required = required;
     data.input = input;
     data.loaded = false;
-    data.persistent = false; // All CLI parameters are not persistent.
     data.cppType = cppName;
 
     // Apply default value.

--- a/src/mlpack/bindings/cli/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/cli/print_doc_functions_impl.hpp
@@ -198,7 +198,7 @@ inline std::string ProgramCall(const std::string& programName)
 
   for (auto& it : parameters)
   {
-    if (!it.second.input || it.second.persistent)
+    if (!it.second.input)
       continue;
 
     // Otherwise, print the name and the default value.

--- a/src/mlpack/bindings/go/go_option.hpp
+++ b/src/mlpack/bindings/go/go_option.hpp
@@ -79,11 +79,6 @@ class GoOption
     data.required = required;
     data.input = input;
     data.loaded = false;
-    // Only "verbose" and "copy_all_inputs" will be persistent.
-    if (identifier == "verbose" /*|| identifier == "copy_all_inputs"*/)
-      data.persistent = true;
-    else
-      data.persistent = false;
     data.cppType = cppName;
 
     data.value = boost::any(defaultValue);

--- a/src/mlpack/bindings/go/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/go/print_doc_functions_impl.hpp
@@ -439,7 +439,7 @@ inline std::string ProgramCall(const std::string& programName)
   // Now iterate over every optional input option.
   for (auto it = parameters.begin(); it != parameters.end(); ++it)
   {
-    if (it->second.input && !it->second.required && !it->second.persistent)
+    if (it->second.input && !it->second.required)
     {
       // Print the input option.
       ossInputs << "param." << util::CamelCase(it->second.name, false) << " = ";

--- a/src/mlpack/bindings/julia/julia_option.hpp
+++ b/src/mlpack/bindings/julia/julia_option.hpp
@@ -64,12 +64,6 @@ class JuliaOption
     data.required = required;
     data.input = input;
     data.loaded = false;
-
-    // Only "verbose" will be persistent.
-    if (identifier == "verbose")
-      data.persistent = true;
-    else
-      data.persistent = false;
     data.cppType = cppName;
 
     // Every parameter we'll get from Julia will have the correct type.

--- a/src/mlpack/bindings/julia/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/julia/print_doc_functions_impl.hpp
@@ -505,8 +505,7 @@ inline std::string ProgramCall(const std::string& programName)
   size_t nonreqInputs = 0;
   for (auto it = parameters.begin(); it != parameters.end(); ++it)
   {
-    if (it->second.input && !it->second.required &&
-       (it->second.name == "verbose" || !it->second.persistent))
+    if (it->second.input && !it->second.required)
     {
       if (inputs == 0 && nonreqInputs == 0)
         result << " ; ";

--- a/src/mlpack/bindings/markdown/md_option.hpp
+++ b/src/mlpack/bindings/markdown/md_option.hpp
@@ -60,12 +60,6 @@ class MDOption
     data.required = required;
     data.input = input;
     data.loaded = false;
-    // Several options from Python and CLI bindings are persistent.
-    if (identifier == "verbose" || identifier == "copy_all_inputs" ||
-        identifier == "help" || identifier == "info" || identifier == "version")
-      data.persistent = true;
-    else
-      data.persistent = false;
     data.cppType = cppName;
 
     // Every parameter we'll get from Markdown will have the correct type.

--- a/src/mlpack/bindings/markdown/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/markdown/print_doc_functions_impl.hpp
@@ -245,7 +245,6 @@ inline std::string PrintTypeDocs()
   data.required = false;
   data.input = true;
   data.loaded = false;
-  data.persistent = false;
   data.value = boost::any(int(0));
 
   std::string type = GetPrintableType<int>(data);

--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -132,7 +132,9 @@ set(CYTHON_SOURCES
   mlpack/matrix_utils.py
   mlpack/serialization.hpp
   mlpack/serialization.pxd
+  mlpack/params.pxd
   mlpack/preprocess_json_params.py
+  mlpack/timers.pxd
 )
 
 set(TEST_SOURCES
@@ -295,7 +297,7 @@ if (BUILD_PYTHON_BINDINGS)
   # Add the convenience import to __init__.py.  Note that this happens during
   # configuration.
   file(APPEND ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/__init__.py
-      "from .${name} import ${name}\n")
+      "from .${name} import ${name}_py\n")
 endif ()
 endmacro ()
 

--- a/src/mlpack/bindings/python/generate_pyx.cpp.in
+++ b/src/mlpack/bindings/python/generate_pyx.cpp.in
@@ -41,9 +41,6 @@ using namespace mlpack::util;
 
 int main(int /* argc */, char** /* argv */)
 {
-  // All the parameters are registered, but stored, so restore them.
-  // programName is defined in mlpack_main.hpp.
-  IO::RestoreSettings(programName);
-
-  PrintPYX(IO::GetSingleton().doc, "${PROGRAM_MAIN_FILE}", "${PROGRAM_NAME}");
+  PrintPYX(IO::Parameters(STRINGIFY(BINDING_NAME)).Doc(), 
+      "${PROGRAM_MAIN_FILE}", STRINGIFY(BINDING_NAME));
 }

--- a/src/mlpack/bindings/python/generate_pyx.cpp.in
+++ b/src/mlpack/bindings/python/generate_pyx.cpp.in
@@ -27,7 +27,6 @@
 #endif
 
 #include <mlpack/core.hpp>
-#include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/bindings/python/print_pyx.hpp>
 
 // This will include the ParamData options that are a part of the program.
@@ -41,6 +40,6 @@ using namespace mlpack::util;
 
 int main(int /* argc */, char** /* argv */)
 {
-  PrintPYX(IO::Parameters(STRINGIFY(BINDING_NAME)).Doc(), 
+  PrintPYX(IO::Parameters(STRINGIFY(BINDING_NAME)).Doc(),
       "${PROGRAM_MAIN_FILE}", STRINGIFY(BINDING_NAME));
 }

--- a/src/mlpack/bindings/python/mlpack/io.pxd
+++ b/src/mlpack/bindings/python/mlpack/io.pxd
@@ -11,43 +11,22 @@ terms of the 3-clause BSD license.  You should have received a copy of the
 http://www.opensource.org/licenses/BSD-3-Clause for more information.
 """
 cimport cython
-
 from libcpp.string cimport string
 from libcpp cimport bool
+from params cimport Params
 
 cdef extern from "<mlpack/core/util/io.hpp>" namespace "mlpack" nogil:
   cdef cppclass IO:
     @staticmethod
-    (T&) GetParam[T](string) nogil except +
-
-    @staticmethod
-    bool HasParam(string) nogil except +
-
-    @staticmethod
-    void SetPassed(string) nogil except +
-
-    @staticmethod
-    void Destroy() nogil except +
-
-    @staticmethod
-    void StoreSettings(string) nogil except +
-
-    @staticmethod
-    void RestoreSettings(string) nogil except +
-
-    @staticmethod
-    void ClearSettings() nogil except +
-
-    @staticmethod
-    void CheckInputMatrices() nogil except +
+    Params Parameters(string) nogil except +
 
 cdef extern from "<mlpack/bindings/python/mlpack/io_util.hpp>" \
     namespace "mlpack::util" nogil:
-  void SetParam[T](string, T&) nogil except +
-  void SetParamPtr[T](string, T*, bool) nogil except +
-  void SetParamWithInfo[T](string, T&, const bool*) nogil except +
-  (T*) GetParamPtr[T](string) nogil except +
-  (T&) GetParamWithInfo[T](string) nogil except +
+  void SetParam[T](Params, string, T&) nogil except +
+  void SetParamPtr[T](Params, string, T*, bool) nogil except +
+  void SetParamWithInfo[T](Params, string, T&, const bool*) nogil except +
+  (T*) GetParamPtr[T](Params, string) nogil except +
+  (T&) GetParamWithInfo[T](Params, string) nogil except +
   void EnableVerbose() nogil except +
   void DisableVerbose() nogil except +
   void DisableBacktrace() nogil except +

--- a/src/mlpack/bindings/python/mlpack/io.pxd
+++ b/src/mlpack/bindings/python/mlpack/io.pxd
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 """
-io.pyx: Cython functionality for mlpack::IO.
+io.pyx: Cython functionality for mlpack::IO and other utilities.
 
-This file imports the GetParam() function from mlpack::IO, plus a utility
-SetParam() function because Cython can't seem to support lvalue references.
+This file imports the Parameters() function from mlpack::IO, plus other utility
+functions: SetParam(), SetParamPtr(), SetParamWithInfo(), GetParam(),
+GetParamWithInfo(), EnableVerbose(), DisableVerbose(), DisableBacktrace(),
+EnableTimers() and ResetTimers().
 
 mlpack is free software; you may redistribute it and/or modify it under the
 terms of the 3-clause BSD license.  You should have received a copy of the

--- a/src/mlpack/bindings/python/mlpack/io_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/io_util.hpp
@@ -12,7 +12,7 @@
  */
 #ifndef MLPACK_BINDINGS_PYTHON_CYTHON_IO_UTIL_HPP
 #define MLPACK_BINDINGS_PYTHON_CYTHON_IO_UTIL_HPP
-
+// TODO: Change this.
 #include <mlpack/core/util/io.hpp>
 #include <mlpack/core/data/dataset_mapper.hpp>
 
@@ -29,9 +29,11 @@ namespace util {
  * @param value Value to set parameter to.
  */
 template<typename T>
-inline void SetParam(const std::string& identifier, T& value)
+inline void SetParam(util::Params& p,
+                     const std::string& identifier,
+                     T& value)
 {
-  IO::GetParam<T>(identifier) = std::move(value);
+  p.Get<T>(identifier) = std::move(value);
 }
 
 /**
@@ -45,18 +47,20 @@ inline void SetParam(const std::string& identifier, T& value)
  * @param copy Whether or not the object should be copied.
  */
 template<typename T>
-inline void SetParamPtr(const std::string& identifier,
+inline void SetParamPtr(util::Params& p,
+                        const std::string& identifier,
                         T* value,
                         const bool copy)
 {
-  IO::GetParam<T*>(identifier) = copy ? new T(*value) : value;
+  p.Get<T*>(identifier) = copy ? new T(*value) : value;
 }
 
 /**
  * Set the parameter (which is a matrix/DatasetInfo tuple) to the given value.
  */
 template<typename T>
-inline void SetParamWithInfo(const std::string& identifier,
+inline void SetParamWithInfo(util::Params& p,
+                             const std::string& identifier,
                              T& matrix,
                              const bool* dims)
 {
@@ -65,8 +69,8 @@ inline void SetParamWithInfo(const std::string& identifier,
 
   // The true type of the parameter is std::tuple<T, DatasetInfo>.
   const size_t dimensions = matrix.n_rows;
-  std::get<1>(IO::GetParam<TupleType>(identifier)) = std::move(matrix);
-  data::DatasetInfo& di = std::get<0>(IO::GetParam<TupleType>(identifier));
+  std::get<1>(p.Get<TupleType>(identifier)) = std::move(matrix);
+  data::DatasetInfo& di = std::get<0>(p.Get<TupleType>(identifier));
   di = data::DatasetInfo(dimensions);
 
   bool hasCategoricals = false;
@@ -83,7 +87,7 @@ inline void SetParamWithInfo(const std::string& identifier,
   if (hasCategoricals)
   {
     arma::vec maxs = arma::max(
-        std::get<1>(IO::GetParam<TupleType>(identifier)), 1);
+        std::get<1>(p.Get<TupleType>(identifier)), 1);
 
     for (size_t i = 0; i < dimensions; ++i)
     {
@@ -106,20 +110,22 @@ inline void SetParamWithInfo(const std::string& identifier,
  * of support for template pointer types.
  */
 template<typename T>
-T* GetParamPtr(const std::string& paramName)
+T* GetParamPtr(util::Params& p,
+               const std::string& paramName)
 {
-  return IO::GetParam<T*>(paramName);
+  return p.Get<T*>(paramName);
 }
 
 /**
  * Return the matrix part of a matrix + dataset info parameter.
  */
 template<typename T>
-T& GetParamWithInfo(const std::string& paramName)
+T& GetParamWithInfo(util::Params& p,
+                    const std::string& paramName)
 {
   // T will be the Armadillo type.
   typedef std::tuple<data::DatasetInfo, T> TupleType;
-  return std::get<1>(IO::GetParam<TupleType>(paramName));
+  return std::get<1>(p.Get<TupleType>(paramName));
 }
 
 /**
@@ -152,7 +158,7 @@ inline void DisableBacktrace()
 inline void ResetTimers()
 {
   // Just get a new object---removes all old timers.
-  IO::GetSingleton().timer.Reset();
+  Timer::ResetAll();
 }
 
 /**

--- a/src/mlpack/bindings/python/mlpack/io_util.hpp
+++ b/src/mlpack/bindings/python/mlpack/io_util.hpp
@@ -12,7 +12,7 @@
  */
 #ifndef MLPACK_BINDINGS_PYTHON_CYTHON_IO_UTIL_HPP
 #define MLPACK_BINDINGS_PYTHON_CYTHON_IO_UTIL_HPP
-// TODO: Change this.
+
 #include <mlpack/core/util/io.hpp>
 #include <mlpack/core/data/dataset_mapper.hpp>
 
@@ -29,11 +29,11 @@ namespace util {
  * @param value Value to set parameter to.
  */
 template<typename T>
-inline void SetParam(util::Params& p,
+inline void SetParam(util::Params& params,
                      const std::string& identifier,
                      T& value)
 {
-  p.Get<T>(identifier) = std::move(value);
+  params.Get<T>(identifier) = std::move(value);
 }
 
 /**
@@ -47,19 +47,19 @@ inline void SetParam(util::Params& p,
  * @param copy Whether or not the object should be copied.
  */
 template<typename T>
-inline void SetParamPtr(util::Params& p,
+inline void SetParamPtr(util::Params& params,
                         const std::string& identifier,
                         T* value,
                         const bool copy)
 {
-  p.Get<T*>(identifier) = copy ? new T(*value) : value;
+  params.Get<T*>(identifier) = copy ? new T(*value) : value;
 }
 
 /**
  * Set the parameter (which is a matrix/DatasetInfo tuple) to the given value.
  */
 template<typename T>
-inline void SetParamWithInfo(util::Params& p,
+inline void SetParamWithInfo(util::Params& params,
                              const std::string& identifier,
                              T& matrix,
                              const bool* dims)
@@ -69,8 +69,8 @@ inline void SetParamWithInfo(util::Params& p,
 
   // The true type of the parameter is std::tuple<T, DatasetInfo>.
   const size_t dimensions = matrix.n_rows;
-  std::get<1>(p.Get<TupleType>(identifier)) = std::move(matrix);
-  data::DatasetInfo& di = std::get<0>(p.Get<TupleType>(identifier));
+  std::get<1>(params.Get<TupleType>(identifier)) = std::move(matrix);
+  data::DatasetInfo& di = std::get<0>(params.Get<TupleType>(identifier));
   di = data::DatasetInfo(dimensions);
 
   bool hasCategoricals = false;
@@ -87,7 +87,7 @@ inline void SetParamWithInfo(util::Params& p,
   if (hasCategoricals)
   {
     arma::vec maxs = arma::max(
-        std::get<1>(p.Get<TupleType>(identifier)), 1);
+        std::get<1>(params.Get<TupleType>(identifier)), 1);
 
     for (size_t i = 0; i < dimensions; ++i)
     {
@@ -110,22 +110,22 @@ inline void SetParamWithInfo(util::Params& p,
  * of support for template pointer types.
  */
 template<typename T>
-T* GetParamPtr(util::Params& p,
+T* GetParamPtr(util::Params& params,
                const std::string& paramName)
 {
-  return p.Get<T*>(paramName);
+  return params.Get<T*>(paramName);
 }
 
 /**
  * Return the matrix part of a matrix + dataset info parameter.
  */
 template<typename T>
-T& GetParamWithInfo(util::Params& p,
+T& GetParamWithInfo(util::Params& params,
                     const std::string& paramName)
 {
   // T will be the Armadillo type.
   typedef std::tuple<data::DatasetInfo, T> TupleType;
-  return std::get<1>(p.Get<TupleType>(paramName));
+  return std::get<1>(params.Get<TupleType>(paramName));
 }
 
 /**

--- a/src/mlpack/bindings/python/mlpack/params.pxd
+++ b/src/mlpack/bindings/python/mlpack/params.pxd
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""
+params.pxd: Cython functionality for mlpack::util::Params.
+
+This file imports the GetParam() function from mlpack::IO, plus a utility
+SetParam() function because Cython can't seem to support lvalue references.
+
+mlpack is free software; you may redistribute it and/or modify it under the
+terms of the 3-clause BSD license.  You should have received a copy of the
+3-clause BSD license along with mlpack.  If not, see
+http://www.opensource.org/licenses/BSD-3-Clause for more information.
+"""
+cimport cython
+from libcpp.string cimport string
+from libcpp cimport bool
+
+cdef extern from "<mlpack/core/util/params.hpp>" namespace "mlpack::util" nogil:
+  cdef cppclass Params:
+    Params() nogil
+    (T&) Get[T](string) nogil except +
+    bool Has(string) nogil except +
+    void SetPassed(string) nogil except +
+    void CheckInputMatrices() nogil except +

--- a/src/mlpack/bindings/python/mlpack/params.pxd
+++ b/src/mlpack/bindings/python/mlpack/params.pxd
@@ -2,8 +2,13 @@
 """
 params.pxd: Cython functionality for mlpack::util::Params.
 
-This file imports the GetParam() function from mlpack::IO, plus a utility
-SetParam() function because Cython can't seem to support lvalue references.
+This file provides the wrapper to the Params class, along with some of
+its methods that are:
+Get() - Used to "get" a reference to a parameter with the given name.
+Has() - Used to know if a parameter with a given name exists in the program.
+SetPassed() - Used to set a parameter as "passed".
+CheckInputMatrices() - Sanity check for matrics to know if a matrix has NULL
+                       or NaN values.
 
 mlpack is free software; you may redistribute it and/or modify it under the
 terms of the 3-clause BSD license.  You should have received a copy of the

--- a/src/mlpack/bindings/python/mlpack/timers.pxd
+++ b/src/mlpack/bindings/python/mlpack/timers.pxd
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-params.pxd: Cython wrapper for Timers.
+timers.pxd: Cython wrapper for Timers.
 
 This file imports the GetParam() function from mlpack::IO, plus a utility
 SetParam() function because Cython can't seem to support lvalue references.

--- a/src/mlpack/bindings/python/mlpack/timers.pxd
+++ b/src/mlpack/bindings/python/mlpack/timers.pxd
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-params.pxd: Cython functionality for mlpack::util::Params.
+params.pxd: Cython wrapper for Timers.
 
 This file imports the GetParam() function from mlpack::IO, plus a utility
 SetParam() function because Cython can't seem to support lvalue references.
@@ -11,8 +11,6 @@ terms of the 3-clause BSD license.  You should have received a copy of the
 http://www.opensource.org/licenses/BSD-3-Clause for more information.
 """
 cimport cython
-from libcpp.string cimport string
-from libcpp cimport bool
 
 cdef extern from "<mlpack/core/util/timers.hpp>" namespace "mlpack::util" nogil:
   cdef cppclass Timers:

--- a/src/mlpack/bindings/python/mlpack/timers.pxd
+++ b/src/mlpack/bindings/python/mlpack/timers.pxd
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+"""
+params.pxd: Cython functionality for mlpack::util::Params.
+
+This file imports the GetParam() function from mlpack::IO, plus a utility
+SetParam() function because Cython can't seem to support lvalue references.
+
+mlpack is free software; you may redistribute it and/or modify it under the
+terms of the 3-clause BSD license.  You should have received a copy of the
+3-clause BSD license along with mlpack.  If not, see
+http://www.opensource.org/licenses/BSD-3-Clause for more information.
+"""
+cimport cython
+from libcpp.string cimport string
+from libcpp cimport bool
+
+cdef extern from "<mlpack/core/util/timers.hpp>" namespace "mlpack::util" nogil:
+  cdef cppclass Timers:
+    Timers() nogil

--- a/src/mlpack/bindings/python/mlpack/timers.pxd
+++ b/src/mlpack/bindings/python/mlpack/timers.pxd
@@ -2,8 +2,8 @@
 """
 timers.pxd: Cython wrapper for Timers.
 
-This file imports the GetParam() function from mlpack::IO, plus a utility
-SetParam() function because Cython can't seem to support lvalue references.
+This file provides a basic wrapper for Timers class, that is used in calling
+the main program function.
 
 mlpack is free software; you may redistribute it and/or modify it under the
 terms of the 3-clause BSD license.  You should have received a copy of the

--- a/src/mlpack/bindings/python/print_doc_functions.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions.hpp
@@ -53,7 +53,7 @@ inline std::string PrintValue(const bool& value, bool quotes);
  * Given a parameter name, print its corresponding default value.
  */
 inline std::string PrintDefault(const std::string& bindingName,
-																const std::string& paramName);
+                                const std::string& paramName);
 
 // Recursion base case.
 inline std::string PrintInputOptions(util::Params& params);

--- a/src/mlpack/bindings/python/print_doc_functions.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions.hpp
@@ -52,10 +52,11 @@ inline std::string PrintValue(const bool& value, bool quotes);
 /**
  * Given a parameter name, print its corresponding default value.
  */
-inline std::string PrintDefault(const std::string& paramName);
+inline std::string PrintDefault(const std::string& bindingName,
+																const std::string& paramName);
 
 // Recursion base case.
-inline std::string PrintInputOptions();
+inline std::string PrintInputOptions(util::Params& params);
 
 /**
  * Print an input option.  This will throw an exception if the parameter does
@@ -63,15 +64,17 @@ inline std::string PrintInputOptions();
  * something like x=5.
  */
 template<typename T, typename... Args>
-std::string PrintInputOptions(const std::string& paramName,
+std::string PrintInputOptions(util::Params& params,
+                              const std::string& paramName,
                               const T& value,
                               Args... args);
 
 // Recursion base case.
-inline std::string PrintOutputOptions();
+inline std::string PrintOutputOptions(util::Params& params);
 
 template<typename T, typename... Args>
-std::string PrintOutputOptions(const std::string& paramName,
+std::string PrintOutputOptions(util::Params& params,
+                               const std::string& paramName,
                                const T& value,
                                Args... args);
 
@@ -110,14 +113,16 @@ inline std::string ParamString(const std::string& paramName);
  * Python bindings, we ignore any checks on output parameters, so if paramName
  * is an output parameter, this returns true.
  */
-inline bool IgnoreCheck(const std::string& paramName);
+inline bool IgnoreCheck(const std::string& bindingName,
+												const std::string& paramName);
 
 /**
  * Print whether or not we should ignore a check on the given set of
  * constraints.  For Python bindings, we ignore any checks on output parameters,
  * so if any parameter is an output parameter, this returns true.
  */
-inline bool IgnoreCheck(const std::vector<std::string>& constraints);
+inline bool IgnoreCheck(const std::string& bindingName,
+												const std::vector<std::string>& constraints);
 
 /**
  * Print whether or not we should ignore a check on the given set of
@@ -126,6 +131,7 @@ inline bool IgnoreCheck(const std::vector<std::string>& constraints);
  * this returns true.
  */
 inline bool IgnoreCheck(
+		const std::string& bindingName,
     const std::vector<std::pair<std::string, bool>>& constraints,
     const std::string& paramName);
 

--- a/src/mlpack/bindings/python/print_doc_functions.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions.hpp
@@ -114,7 +114,7 @@ inline std::string ParamString(const std::string& paramName);
  * is an output parameter, this returns true.
  */
 inline bool IgnoreCheck(const std::string& bindingName,
-												const std::string& paramName);
+                          const std::string& paramName);
 
 /**
  * Print whether or not we should ignore a check on the given set of

--- a/src/mlpack/bindings/python/print_doc_functions.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions.hpp
@@ -131,7 +131,7 @@ inline bool IgnoreCheck(const std::string& bindingName,
  * this returns true.
  */
 inline bool IgnoreCheck(
-		const std::string& bindingName,
+    const std::string& bindingName,
     const std::vector<std::pair<std::string, bool>>& constraints,
     const std::string& paramName);
 

--- a/src/mlpack/bindings/python/print_doc_functions.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions.hpp
@@ -122,7 +122,7 @@ inline bool IgnoreCheck(const std::string& bindingName,
  * so if any parameter is an output parameter, this returns true.
  */
 inline bool IgnoreCheck(const std::string& bindingName,
-												const std::vector<std::string>& constraints);
+                          const std::vector<std::string>& constraints);
 
 /**
  * Print whether or not we should ignore a check on the given set of

--- a/src/mlpack/bindings/python/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions_impl.hpp
@@ -107,15 +107,18 @@ inline std::string PrintValue(const bool& value, bool quotes)
 /**
  * Given a parameter name, print its corresponding default value.
  */
-inline std::string PrintDefault(const std::string& paramName)
+inline std::string PrintDefault(const std::string& bindingName,
+                                const std::string& paramName)
 {
-  if (IO::Parameters().count(paramName) == 0)
+	util::Params p = IO::Parameters(bindingName);
+
+  if (p.Parameters().count(paramName) == 0)
     throw std::invalid_argument("unknown parameter " + paramName + "!");
 
-  util::ParamData& d = IO::Parameters()[paramName];
+  util::ParamData& d = p.Parameters()[paramName];
 
   std::string defaultValue;
-  IO::GetSingleton().functionMap[d.tname]["DefaultParam"](d, NULL,
+  p.functionMap[d.tname]["DefaultParam"](d, NULL,
       (void*) &defaultValue);
 
   return defaultValue;
@@ -130,15 +133,18 @@ std::string PrintInputOptions() { return ""; }
  * something like x=5.
  */
 template<typename T, typename... Args>
-std::string PrintInputOptions(const std::string& paramName,
+std::string PrintInputOptions(const std::string& bindingName,
+															const std::string& paramName,
                               const T& value,
                               Args... args)
 {
+	util::Params p = IO::Parameters(bindingName);
+
   // See if this is part of the program.
   std::string result = "";
-  if (IO::Parameters().count(paramName) > 0)
+  if (p.Parameters().count(paramName) > 0)
   {
-    util::ParamData& d = IO::Parameters()[paramName];
+    util::ParamData& d = p.Parameters()[paramName];
     if (d.input)
     {
       // Print the input option.
@@ -173,15 +179,18 @@ std::string PrintInputOptions(const std::string& paramName,
 inline std::string PrintOutputOptions() { return ""; }
 
 template<typename T, typename... Args>
-std::string PrintOutputOptions(const std::string& paramName,
+std::string PrintOutputOptions(const std::string& bindingName,
+															 const std::string& paramName,
                                const T& value,
                                Args... args)
 {
+	util::Params p = IO::Parameters(bindingName);
+
   // See if this is part of the program.
   std::string result = "";
-  if (IO::Parameters().count(paramName) > 0)
+  if (p.Parameters().count(paramName) > 0)
   {
-    util::ParamData& d = IO::Parameters()[paramName];
+    util::ParamData& d = p.Parameters()[paramName];
     if (!d.input)
     {
       // Print a new line for the output option.
@@ -244,13 +253,15 @@ std::string ProgramCall(const std::string& programName, Args... args)
  * Given the name of a binding, print a program call assuming that all options
  * are specified.  The programName should not be the output of GetBindingName().
  */
-inline std::string ProgramCall(const std::string& programName)
+inline std::string ProgramCall(const std::string& programName) // TODO: here programName is the bindingName??
 {
+	util::Params p = IO::Parameters()[programName];
+
   std::ostringstream oss;
   oss << ">>> ";
 
   // Determine if we have any output options.
-  std::map<std::string, util::ParamData>& parameters = IO::Parameters();
+  std::map<std::string, util::ParamData>& parameters = p.Parameters();
   bool hasOutput = false;
   for (auto it = parameters.begin(); it != parameters.end(); ++it)
   {
@@ -286,7 +297,7 @@ inline std::string ProgramCall(const std::string& programName)
       oss << it->second.name << "_=";
 
     std::string value;
-    IO::GetSingleton().functionMap[it->second.tname]["DefaultParam"](
+    p.functionMap[it->second.tname]["DefaultParam"](
         it->second, NULL, (void*) &value);
     oss << value;
   }
@@ -367,16 +378,21 @@ inline std::string ParamString(const std::string& paramName, const T& value)
   return oss.str();
 }
 
-inline bool IgnoreCheck(const std::string& paramName)
+inline bool IgnoreCheck(const std::string& bindingName,
+												const std::string& paramName)
 {
-  return !IO::Parameters()[paramName].input;
+	util::Params p = IO::Parameters(bindingName);
+  return !p.Parameters()[paramName].input;
 }
 
-inline bool IgnoreCheck(const std::vector<std::string>& constraints)
+inline bool IgnoreCheck(const std::string& bindingName,
+												const std::vector<std::string>& constraints)
 {
+	util::Params p = IO::Parameters(bindingName);
+
   for (size_t i = 0; i < constraints.size(); ++i)
   {
-    if (!IO::Parameters()[constraints[i]].input)
+    if (!p.Parameters()[constraints[i]].input)
       return true;
   }
 
@@ -384,16 +400,19 @@ inline bool IgnoreCheck(const std::vector<std::string>& constraints)
 }
 
 inline bool IgnoreCheck(
+		const std::string& bindingName,
     const std::vector<std::pair<std::string, bool>>& constraints,
     const std::string& paramName)
 {
+	util::Params p = IO::Parameters(bindingName);
+
   for (size_t i = 0; i < constraints.size(); ++i)
   {
-    if (!IO::Parameters()[constraints[i].first].input)
+    if (!p.Parameters()[constraints[i].first].input)
       return true;
   }
 
-  return !IO::Parameters()[paramName].input;
+  return !p.Parameters()[paramName].input;
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions_impl.hpp
@@ -377,14 +377,14 @@ inline std::string ParamString(const std::string& paramName, const T& value)
 }
 
 inline bool IgnoreCheck(const std::string& bindingName,
-												const std::string& paramName)
+			const std::string& paramName)
 {
 	util::Params p = IO::Parameters(bindingName);
   return !p.Parameters()[paramName].input;
 }
 
 inline bool IgnoreCheck(const std::string& bindingName,
-												const std::vector<std::string>& constraints)
+		        const std::vector<std::string>& constraints)
 {
 	util::Params p = IO::Parameters(bindingName);
 

--- a/src/mlpack/bindings/python/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions_impl.hpp
@@ -279,8 +279,7 @@ inline std::string ProgramCall(const std::string& bindingName)
   bool first = true;
   for (auto it = parameters.begin(); it != parameters.end(); ++it)
   {
-    if (!it->second.input || (it->second.persistent &&
-        it->second.name != "verbose"))
+    if (!it->second.input)
       continue;
 
     if (!first)

--- a/src/mlpack/bindings/python/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions_impl.hpp
@@ -110,7 +110,7 @@ inline std::string PrintValue(const bool& value, bool quotes)
 inline std::string PrintDefault(const std::string& bindingName,
                                 const std::string& paramName)
 {
-	util::Params p = IO::Parameters(bindingName);
+  util::Params p = IO::Parameters(bindingName);
 
   if (p.Parameters().count(paramName) == 0)
     throw std::invalid_argument("unknown parameter " + paramName + "!");
@@ -253,7 +253,7 @@ std::string ProgramCall(const std::string& programName, Args... args)
  */
 inline std::string ProgramCall(const std::string& programName) // TODO: here programName is the bindingName??
 {
-	util::Params params = IO::Parameters(programName);
+  util::Params params = IO::Parameters(programName);
 
   std::ostringstream oss;
   oss << ">>> ";
@@ -379,14 +379,14 @@ inline std::string ParamString(const std::string& paramName, const T& value)
 inline bool IgnoreCheck(const std::string& bindingName,
 			const std::string& paramName)
 {
-	util::Params p = IO::Parameters(bindingName);
+  util::Params p = IO::Parameters(bindingName);
   return !p.Parameters()[paramName].input;
 }
 
 inline bool IgnoreCheck(const std::string& bindingName,
 		        const std::vector<std::string>& constraints)
 {
-	util::Params p = IO::Parameters(bindingName);
+  util::Params p = IO::Parameters(bindingName);
 
   for (size_t i = 0; i < constraints.size(); ++i)
   {
@@ -398,11 +398,11 @@ inline bool IgnoreCheck(const std::string& bindingName,
 }
 
 inline bool IgnoreCheck(
-		const std::string& bindingName,
+    const std::string& bindingName,
     const std::vector<std::pair<std::string, bool>>& constraints,
     const std::string& paramName)
 {
-	util::Params p = IO::Parameters(bindingName);
+  util::Params p = IO::Parameters(bindingName);
 
   for (size_t i = 0; i < constraints.size(); ++i)
   {

--- a/src/mlpack/bindings/python/print_doc_functions_impl.hpp
+++ b/src/mlpack/bindings/python/print_doc_functions_impl.hpp
@@ -110,15 +110,15 @@ inline std::string PrintValue(const bool& value, bool quotes)
 inline std::string PrintDefault(const std::string& bindingName,
                                 const std::string& paramName)
 {
-  util::Params p = IO::Parameters(bindingName);
+  util::Params params = IO::Parameters(bindingName);
 
-  if (p.Parameters().count(paramName) == 0)
+  if (params.Parameters().count(paramName) == 0)
     throw std::invalid_argument("unknown parameter " + paramName + "!");
 
-  util::ParamData& d = p.Parameters()[paramName];
+  util::ParamData& d = params.Parameters()[paramName];
 
   std::string defaultValue;
-  p.functionMap[d.tname]["DefaultParam"](d, NULL,
+  params.functionMap[d.tname]["DefaultParam"](d, NULL,
       (void*) &defaultValue);
 
   return defaultValue;
@@ -214,13 +214,13 @@ std::string PrintOutputOptions(util::Params& params,
 
 /**
  * Given a name of a binding and a variable number of arguments (and their
- * contents), print the corresponding function call.  The given programName
+ * contents), print the corresponding function call.  The given bindingName
  * should not be the output of GetBindingName().
  */
 template<typename... Args>
-std::string ProgramCall(const std::string& programName, Args... args)
+std::string ProgramCall(const std::string& bindingName, Args... args)
 {
-  util::Params params = IO::Parameters(programName);
+  util::Params params = IO::Parameters(bindingName);
 
   std::ostringstream oss;
   oss << ">>> ";
@@ -230,7 +230,7 @@ std::string ProgramCall(const std::string& programName, Args... args)
   ossOutput << PrintOutputOptions(params, args...);
   if (ossOutput.str() != "")
     oss << "output = ";
-  oss << programName << "(";
+  oss << bindingName << "(";
 
   // Now process each input option.
   oss << PrintInputOptions(params, args...);
@@ -249,11 +249,11 @@ std::string ProgramCall(const std::string& programName, Args... args)
 
 /**
  * Given the name of a binding, print a program call assuming that all options
- * are specified.  The programName should not be the output of GetBindingName().
+ * are specified.  The bindingName should not be the output of GetBindingName().
  */
-inline std::string ProgramCall(const std::string& programName) // TODO: here programName is the bindingName??
+inline std::string ProgramCall(const std::string& bindingName)
 {
-  util::Params params = IO::Parameters(programName);
+  util::Params params = IO::Parameters(bindingName);
 
   std::ostringstream oss;
   oss << ">>> ";
@@ -273,7 +273,7 @@ inline std::string ProgramCall(const std::string& programName) // TODO: here pro
   if (hasOutput)
     oss << "d = ";
 
-  oss << programName << "(";
+  oss << bindingName << "(";
 
   // Now iterate over every input option.
   bool first = true;
@@ -377,20 +377,20 @@ inline std::string ParamString(const std::string& paramName, const T& value)
 }
 
 inline bool IgnoreCheck(const std::string& bindingName,
-			const std::string& paramName)
+                        const std::string& paramName)
 {
-  util::Params p = IO::Parameters(bindingName);
-  return !p.Parameters()[paramName].input;
+  util::Params params = IO::Parameters(bindingName);
+  return !params.Parameters()[paramName].input;
 }
 
 inline bool IgnoreCheck(const std::string& bindingName,
-		        const std::vector<std::string>& constraints)
+                        const std::vector<std::string>& constraints)
 {
-  util::Params p = IO::Parameters(bindingName);
+  util::Params params = IO::Parameters(bindingName);
 
   for (size_t i = 0; i < constraints.size(); ++i)
   {
-    if (!p.Parameters()[constraints[i]].input)
+    if (!params.Parameters()[constraints[i]].input)
       return true;
   }
 
@@ -402,15 +402,15 @@ inline bool IgnoreCheck(
     const std::vector<std::pair<std::string, bool>>& constraints,
     const std::string& paramName)
 {
-  util::Params p = IO::Parameters(bindingName);
+  util::Params params = IO::Parameters(bindingName);
 
   for (size_t i = 0; i < constraints.size(); ++i)
   {
-    if (!p.Parameters()[constraints[i].first].input)
+    if (!params.Parameters()[constraints[i].first].input)
       return true;
   }
 
-  return !p.Parameters()[paramName].input;
+  return !params.Parameters()[paramName].input;
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/print_input_processing.hpp
+++ b/src/mlpack/bindings/python/print_input_processing.hpp
@@ -57,8 +57,8 @@ void PrintInputProcessing(
    * # Detect if the parameter was passed; set if so.
    * if param_name is not None:
    *   if isinstance(param_name, int):
-   *     SetParam[int](\<const string\> 'param_name', param_name)
-   *     IO.SetPassed(\<const string\> 'param_name')
+   *     SetParam[int](p, \<const string\> 'param_name', param_name)
+   *     p.SetPassed(\<const string\> 'param_name')
    *   else:
    *     raise TypeError("'param_name' must have type 'list'!")
    */
@@ -82,13 +82,13 @@ void PrintInputProcessing(
     }
 
     std::cout << prefix << "    SetParam[" << GetCythonType<T>(d)
-        << "](<const string> '" << d.name << "', ";
+        << "](p, <const string> '" << d.name << "', ";
     if (GetCythonType<T>(d) == "string")
       std::cout << name << ".encode(\"UTF-8\")";
     else
       std::cout << name;
     std::cout << ")" << std::endl;
-    std::cout << prefix << "    IO.SetPassed(<const string> '" << d.name
+    std::cout << prefix << "    p.SetPassed(<const string> '" << d.name
         << "')" << std::endl;
 
     // If this parameter is "verbose", then enable verbose output.
@@ -127,7 +127,7 @@ void PrintInputProcessing(
           << GetPrintableType<T>(d) << "):" << std::endl;
     }
 
-    std::cout << prefix << "    SetParam[" << GetCythonType<T>(d) << "](<const "
+    std::cout << prefix << "    SetParam[" << GetCythonType<T>(d) << "](p, <const "
         << "string> '" << d.name << "', ";
     if (GetCythonType<T>(d) == "string")
       std::cout << name << ".encode(\"UTF-8\")";
@@ -136,7 +136,7 @@ void PrintInputProcessing(
     else
       std::cout << name;
     std::cout << ")" << std::endl;
-    std::cout << prefix << "    IO.SetPassed(<const string> '"
+    std::cout << prefix << "    p.SetPassed(<const string> '"
         << d.name << "')" << std::endl;
 
     if (GetPrintableType<T>(d) == "bool")
@@ -178,8 +178,8 @@ void PrintInputProcessing(
    *    if isinstance(param_name, list):
    *      if len(param_name) > 0:
    *        if isinstance(param_name[0], str):
-   *          SetParam[vector[string]](\<const string\> 'param_name', param_name)
-   *          IO.SetPassed(\<const string\> 'param_name')
+   *          SetParam[vector[string]](p, \<const string\> 'param_name', param_name)
+   *          p.SetPassed(\<const string\> 'param_name')
    *        else:
    *          raise TypeError("'param_name' must have type 'list of strs'!")
    *    else:
@@ -199,14 +199,14 @@ void PrintInputProcessing(
     std::cout << prefix << "      if isinstance(" << d.name << "[0], "
         << GetPrintableType<typename T::value_type>(d) << "):" << std::endl;
     std::cout << prefix << "        SetParam[" << GetCythonType<T>(d)
-        << "](<const string> '" << d.name << "', ";
+        << "](p, <const string> '" << d.name << "', ";
     // Strings need special handling.
     if (GetCythonType<T>(d) == "vector[string]")
       std::cout << "[i.encode(\"UTF-8\") for i in " << d.name << "]";
     else
       std::cout << d.name;
     std::cout << ")" << std::endl;
-    std::cout << prefix << "        IO.SetPassed(<const string> '" << d.name
+    std::cout << prefix << "        p.SetPassed(<const string> '" << d.name
         << "')" << std::endl;
     std::cout << prefix << "      else:" << std::endl;
     std::cout << prefix << "        raise TypeError(" <<"\"'"<< d.name
@@ -225,14 +225,14 @@ void PrintInputProcessing(
     std::cout << prefix << "    if isinstance(" << d.name << "[0], "
         << GetPrintableType<typename T::value_type>(d) << "):" << std::endl;
     std::cout << prefix << "      SetParam[" << GetCythonType<T>(d)
-        << "](<const string> '" << d.name << "', ";
+        << "](p, <const string> '" << d.name << "', ";
     // Strings need special handling.
     if (GetCythonType<T>(d) == "vector[string]")
       std::cout << "[i.encode(\"UTF-8\") for i in " << d.name << "]";
     else
       std::cout << d.name;
     std::cout << ")" << std::endl;
-    std::cout << prefix << "      IO.SetPassed(<const string> '" << d.name
+    std::cout << prefix << "      p.SetPassed(<const string> '" << d.name
         << "')" << std::endl;
     std::cout << prefix << "    else:" << std::endl;
     std::cout << prefix << "      raise TypeError(" <<"\"'"<< d.name
@@ -267,8 +267,8 @@ void PrintInputProcessing(
    *     param_name_tuple[0].shape = (param_name_tuple[0].size,)
    *   param_name_mat = arma_numpy.numpy_to_mat_s(param_name_tuple[0],
    *       param_name_tuple[1])
-   *   SetParam[mat](\<const string\> 'param_name', dereference(param_name_mat))
-   *   IO.SetPassed(\<const string\> 'param_name')
+   *   SetParam[mat](p, \<const string\> 'param_name', dereference(param_name_mat))
+   *   p.SetPassed(\<const string\> 'param_name')
    *
    */
   std::cout << prefix << "# Detect if the parameter was passed; set if so."
@@ -280,7 +280,7 @@ void PrintInputProcessing(
       std::cout << prefix << "if " << d.name << " is not None:" << std::endl;
       std::cout << prefix << "  " << d.name << "_tuple = to_matrix("
           << d.name << ", dtype=" << GetNumpyType<typename T::elem_type>()
-          << ", copy=IO.HasParam('copy_all_inputs'))" << std::endl;
+          << ", copy=p.Has('copy_all_inputs'))" << std::endl;
       std::cout << prefix << "  if len(" << d.name << "_tuple[0].shape) > 1:"
           << std::endl;
       std::cout << prefix << "    if " << d.name << "_tuple[0]"
@@ -292,9 +292,9 @@ void PrintInputProcessing(
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << d.name
           << "_tuple[0], " << d.name << "_tuple[1])" << std::endl;
       std::cout << prefix << "  SetParam[" << GetCythonType<T>(d)
-          << "](<const string> '" << d.name << "', dereference("
+          << "](p, <const string> '" << d.name << "', dereference("
           << d.name << "_mat))"<< std::endl;
-      std::cout << prefix << "  IO.SetPassed(<const string> '" << d.name
+      std::cout << prefix << "  p.SetPassed(<const string> '" << d.name
           << "')" << std::endl;
       std::cout << prefix << "  del " << d.name << "_mat" << std::endl;
     }
@@ -303,7 +303,7 @@ void PrintInputProcessing(
       std::cout << prefix << "if " << d.name << " is not None:" << std::endl;
       std::cout << prefix << "  " << d.name << "_tuple = to_matrix("
           << d.name << ", dtype=" << GetNumpyType<typename T::elem_type>()
-          << ", copy=IO.HasParam('copy_all_inputs'))" << std::endl;
+          << ", copy=p.Has('copy_all_inputs'))" << std::endl;
       std::cout << prefix << "  if len(" << d.name << "_tuple[0].shape"
           << ") < 2:" << std::endl;
       std::cout << prefix << "    " << d.name << "_tuple[0].shape = (" << d.name
@@ -312,9 +312,9 @@ void PrintInputProcessing(
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << d.name
           << "_tuple[0], " << d.name << "_tuple[1])" << std::endl;
       std::cout << prefix << "  SetParam[" << GetCythonType<T>(d)
-          << "](<const string> '" << d.name << "', dereference("
+          << "](p, <const string> '" << d.name << "', dereference("
           << d.name << "_mat))"<< std::endl;
-      std::cout << prefix << "  IO.SetPassed(<const string> '" << d.name
+      std::cout << prefix << "  p.SetPassed(<const string> '" << d.name
           << "')" << std::endl;
       std::cout << prefix << "  del " << d.name << "_mat" << std::endl;
     }
@@ -325,7 +325,7 @@ void PrintInputProcessing(
     {
       std::cout << prefix << d.name << "_tuple = to_matrix(" << d.name
           << ", dtype=" << GetNumpyType<typename T::elem_type>()
-          << ", copy=IO.HasParam('copy_all_inputs'))" << std::endl;
+          << ", copy=p.Has('copy_all_inputs'))" << std::endl;
       std::cout << prefix << "if len(" << d.name << "_tuple[0].shape) > 1:"
           << std::endl;
       std::cout << prefix << "  if " << d.name << "_tuple[0].shape[0] == 1 or "
@@ -336,9 +336,9 @@ void PrintInputProcessing(
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << d.name
           << "_tuple[0], " << d.name << "_tuple[1])" << std::endl;
       std::cout << prefix << "SetParam[" << GetCythonType<T>(d)
-          << "](<const string> '" << d.name << "', dereference("
+          << "](p, <const string> '" << d.name << "', dereference("
           << d.name << "_mat))"<< std::endl;
-      std::cout << prefix << "IO.SetPassed(<const string> '" << d.name << "')"
+      std::cout << prefix << "p.SetPassed(<const string> '" << d.name << "')"
           << std::endl;
       std::cout << prefix << "del " << d.name << "_mat" << std::endl;
     }
@@ -346,7 +346,7 @@ void PrintInputProcessing(
     {
       std::cout << prefix << d.name << "_tuple = to_matrix(" << d.name
           << ", dtype=" << GetNumpyType<typename T::elem_type>()
-          << ", copy=IO.HasParam('copy_all_inputs'))" << std::endl;
+          << ", copy=p.Has('copy_all_inputs'))" << std::endl;
       std::cout << prefix << "if len(" << d.name << "_tuple[0].shape) > 2:"
           << std::endl;
       std::cout << prefix << "  " << d.name << "_tuple[0].shape = (" << d.name
@@ -355,9 +355,9 @@ void PrintInputProcessing(
           << GetArmaType<T>() << "_" << GetNumpyTypeChar<T>() << "(" << d.name
           << "_tuple[0], " << d.name << "_tuple[1])" << std::endl;
       std::cout << prefix << "SetParam[" << GetCythonType<T>(d)
-          << "](<const string> '" << d.name << "', dereference(" << d.name
+          << "](p, <const string> '" << d.name << "', dereference(" << d.name
           << "_mat))" << std::endl;
-      std::cout << prefix << "IO.SetPassed(<const string> '" << d.name << "')"
+      std::cout << prefix << "p.SetPassed(<const string> '" << d.name << "')"
           << std::endl;
       std::cout << prefix << "del " << d.name << "_mat" << std::endl;
     }
@@ -388,15 +388,15 @@ void PrintInputProcessing(
    * # Detect if the parameter was passed; set if so.
    * if param_name is not None:
    *   try:
-   *     SetParamPtr[Model]('param_name', (\<ModelType?\> param_name).modelptr,
-   *         IO.HasParam('copy_all_inputs'))
+   *     SetParamPtr[Model](p, 'param_name', (\<ModelType?\> param_name).modelptr,
+   *         p.Has('copy_all_inputs'))
    *   except TypeError as e:
    *     if type(param_name).__name__ == "ModelType":
-   *       SetParamPtr[Model]('param_name', (\<ModelType\> param_name).modelptr,
-   *           IO.HasParam('copy_all_inputs'))
+   *       SetParamPtr[Model](p, 'param_name', (\<ModelType\> param_name).modelptr,
+   *           p.Has('copy_all_inputs'))
    *     else:
    *       raise e
-   *   IO.SetPassed(\<const string\> 'param_name')
+   *   p.SetPassed(<const string> 'param_name')
    */
   std::cout << prefix << "# Detect if the parameter was passed; set if so."
       << std::endl;
@@ -404,35 +404,35 @@ void PrintInputProcessing(
   {
     std::cout << prefix << "if " << d.name << " is not None:" << std::endl;
     std::cout << prefix << "  try:" << std::endl;
-    std::cout << prefix << "    SetParamPtr[" << strippedType << "]('" << d.name
+    std::cout << prefix << "    SetParamPtr[" << strippedType << "](p, '" << d.name
         << "', (<" << strippedType << "Type?> " << d.name << ").modelptr, "
-        << "IO.HasParam('copy_all_inputs'))" << std::endl;
+        << "p.Has('copy_all_inputs'))" << std::endl;
     std::cout << prefix << "  except TypeError as e:" << std::endl;
     std::cout << prefix << "    if type(" << d.name << ").__name__ == '"
         << strippedType << "Type':" << std::endl;
-    std::cout << prefix << "      SetParamPtr[" << strippedType << "]('"
+    std::cout << prefix << "      SetParamPtr[" << strippedType << "](p, '"
         << d.name << "', (<" << strippedType << "Type> " << d.name
-        << ").modelptr, IO.HasParam('copy_all_inputs'))" << std::endl;
+        << ").modelptr, p.Has('copy_all_inputs'))" << std::endl;
     std::cout << prefix << "    else:" << std::endl;
     std::cout << prefix << "      raise e" << std::endl;
-    std::cout << prefix << "  IO.SetPassed(<const string> '" << d.name << "')"
+    std::cout << prefix << "  p.SetPassed(<const string> '" << d.name << "')"
         << std::endl;
   }
   else
   {
     std::cout << prefix << "try:" << std::endl;
-    std::cout << prefix << "  SetParamPtr[" << strippedType << "]('" << d.name
+    std::cout << prefix << "  SetParamPtr[" << strippedType << "](p, '" << d.name
         << "', (<" << strippedType << "Type?> " << d.name << ").modelptr, "
-        << "IO.HasParam('copy_all_inputs'))" << std::endl;
+        << "p.Has('copy_all_inputs'))" << std::endl;
     std::cout << prefix << "except TypeError as e:" << std::endl;
     std::cout << prefix << "  if type(" << d.name << ").__name__ == '"
         << strippedType << "Type':" << std::endl;
-    std::cout << prefix << "    SetParamPtr[" << strippedType << "]('" << d.name
+    std::cout << prefix << "    SetParamPtr[" << strippedType << "](p,'" << d.name
         << "', (<" << strippedType << "Type> " << d.name << ").modelptr, "
-        << "IO.HasParam('copy_all_inputs'))" << std::endl;
+        << "p.Has('copy_all_inputs'))" << std::endl;
     std::cout << prefix << "  else:" << std::endl;
     std::cout << prefix << "    raise e" << std::endl;
-    std::cout << prefix << "IO.SetPassed(<const string> '" << d.name << "')"
+    std::cout << prefix << "p.SetPassed(<const string> '" << d.name << "')"
         << std::endl;
   }
   std::cout << std::endl;
@@ -459,9 +459,9 @@ void PrintInputProcessing(
    *   if len(param_name_tuple[0].shape) < 2:
    *     param_name_tuple[0].shape = (param_name_tuple[0].size,)
    *   param_name_mat = arma_numpy.numpy_to_matrix_d(param_name_tuple[0])
-   *   SetParamWithInfo[mat](\<const string\> 'param_name',
+   *   SetParamWithInfo[mat](p, \<const string\> 'param_name',
    *       dereference(param_name_mat), &param_name_tuple[1][0])
-   *   IO.SetPassed(\<const string\> 'param_name')
+   *   p.SetPassed(\<const string\> 'param_name')
    */
   std::cout << prefix << "cdef np.ndarray " << d.name << "_dims" << std::endl;
   std::cout << prefix << "# Detect if the parameter was passed; set if so."
@@ -470,7 +470,7 @@ void PrintInputProcessing(
   {
     std::cout << prefix << "if " << d.name << " is not None:" << std::endl;
     std::cout << prefix << "  " << d.name << "_tuple = to_matrix_with_info("
-        << d.name << ", dtype=np.double, copy=IO.HasParam('copy_all_inputs'))"
+        << d.name << ", dtype=np.double, copy=p.Has('copy_all_inputs'))"
         << std::endl;
     std::cout << prefix << "  if len(" << d.name << "_tuple[0].shape"
         << ") < 2:" << std::endl;
@@ -480,17 +480,17 @@ void PrintInputProcessing(
         << d.name << "_tuple[0], " << d.name << "_tuple[1])" << std::endl;
     std::cout << prefix << "  " << d.name << "_dims = " << d.name
         << "_tuple[2]" << std::endl;
-    std::cout << prefix << "  SetParamWithInfo[arma.Mat[double]](<const "
+    std::cout << prefix << "  SetParamWithInfo[arma.Mat[double]](p, <const "
         << "string> '" << d.name << "', dereference(" << d.name << "_mat), "
         << "<const cbool*> " << d.name << "_dims.data)" << std::endl;
-    std::cout << prefix << "  IO.SetPassed(<const string> '" << d.name
+    std::cout << prefix << "  p.SetPassed(<const string> '" << d.name
         << "')" << std::endl;
     std::cout << prefix << "  del " << d.name << "_mat" << std::endl;
   }
   else
   {
     std::cout << prefix << d.name << "_tuple = to_matrix_with_info(" << d.name
-        << ", dtype=np.double, copy=IO.HasParam('copy_all_inputs'))"
+        << ", dtype=np.double, copy=p.Has('copy_all_inputs'))"
         << std::endl;
     std::cout << prefix << "if len(" << d.name << "_tuple[0].shape"
         << ") < 2:" << std::endl;
@@ -500,10 +500,10 @@ void PrintInputProcessing(
         << d.name << "_tuple[0], " << d.name << "_tuple[1])" << std::endl;
     std::cout << prefix << d.name << "_dims = " << d.name << "_tuple[2]"
         << std::endl;
-    std::cout << prefix << "SetParamWithInfo[arma.Mat[double]](<const "
+    std::cout << prefix << "SetParamWithInfo[arma.Mat[double]](p, <const "
         << "string> '" << d.name << "', dereference(" << d.name << "_mat), "
         << "<const cbool*> " << d.name << "_dims.data)" << std::endl;
-    std::cout << prefix << "IO.SetPassed(<const string> '" << d.name << "')"
+    std::cout << prefix << "p.SetPassed(<const string> '" << d.name << "')"
         << std::endl;
     std::cout << prefix << "del " << d.name << "_mat" << std::endl;
   }

--- a/src/mlpack/bindings/python/print_output_processing.hpp
+++ b/src/mlpack/bindings/python/print_output_processing.hpp
@@ -27,6 +27,7 @@ namespace python {
  */
 template<typename T>
 void PrintOutputProcessing(
+    util::Params& /* params */,
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
@@ -42,9 +43,9 @@ void PrintOutputProcessing(
     /**
      * This gives us code like:
      *
-     * result = IO.GetParam[int]('param_name')
+     * result = p.Get[int]('param_name')
      */
-    std::cout << prefix << "result = " << "IO.GetParam[" << GetCythonType<T>(d)
+    std::cout << prefix << "result = " << "p.Get[" << GetCythonType<T>(d)
         << "](\"" << d.name << "\")";
     if (GetCythonType<T>(d) == "string")
     {
@@ -61,9 +62,9 @@ void PrintOutputProcessing(
     /**
      * This gives us code like:
      *
-     * result['param_name'] = IO.GetParam[int]('param_name')
+     * result['param_name'] = p.Get[int]('param_name')
      */
-    std::cout << prefix << "result['" << d.name << "'] = IO.GetParam["
+    std::cout << prefix << "result['" << d.name << "'] = p.Get["
         << GetCythonType<T>(d) << "](\"" << d.name << "\")" << std::endl;
     if (GetCythonType<T>(d) == "string")
     {
@@ -83,6 +84,7 @@ void PrintOutputProcessing(
  */
 template<typename T>
 void PrintOutputProcessing(
+    util::Params& /* params */,
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
@@ -95,12 +97,12 @@ void PrintOutputProcessing(
     /**
      * This gives us code like:
      *
-     * result = arma_numpy.mat_to_numpy_X(IO.GetParam[mat]("name"))
+     * result = arma_numpy.mat_to_numpy_X(p.Get[mat]("name"))
      *
      * where X indicates the type to convert to.
      */
     std::cout << prefix << "result = arma_numpy." << GetArmaType<T>()
-        << "_to_numpy_" << GetNumpyTypeChar<T>() << "(IO.GetParam["
+        << "_to_numpy_" << GetNumpyTypeChar<T>() << "(p.Get["
         << GetCythonType<T>(d) << "](\"" << d.name << "\"))" << std::endl;
   }
   else
@@ -109,13 +111,13 @@ void PrintOutputProcessing(
      * This gives us code like:
      *
      * result['param_name'] =
-     *     arma_numpy.mat_to_numpy_X(IO.GetParam[mat]('name')
+     *     arma_numpy.mat_to_numpy_X(p.Get[mat]('name')
      *
      * where X indicates the type to convert to.
      */
     std::cout << prefix << "result['" << d.name
         << "'] = arma_numpy." << GetArmaType<T>() << "_to_numpy_"
-        << GetNumpyTypeChar<T>() << "(IO.GetParam[" << GetCythonType<T>(d)
+        << GetNumpyTypeChar<T>() << "(p.Get[" << GetCythonType<T>(d)
         << "]('" << d.name << "'))" << std::endl;
   }
 }
@@ -125,6 +127,7 @@ void PrintOutputProcessing(
  */
 template<typename T>
 void PrintOutputProcessing(
+    util::Params& /* params */,
     util::ParamData& d,
     const size_t indent,
     const bool onlyOutput,
@@ -140,11 +143,11 @@ void PrintOutputProcessing(
     /**
      * This gives us code like:
      *
-     * result = arma_numpy.mat_to_numpy_X(GetParamWithInfo[mat]('name'))
+     * result = arma_numpy.mat_to_numpy_X(GetParamWithInfo[mat](p, 'name'))
      */
     std::cout << prefix << "result = arma_numpy.mat_to_numpy_"
         << GetNumpyTypeChar<arma::mat>()
-        << "(GetParamWithInfo[arma.Mat[double]]('" << d.name << "'))"
+        << "(GetParamWithInfo[arma.Mat[double]](p, '" << d.name << "'))"
         << std::endl;
   }
   else
@@ -153,11 +156,11 @@ void PrintOutputProcessing(
      * This gives us code like:
      *
      * result['param_name'] =
-     *     arma_numpy.mat_to_numpy_X(GetParamWithInfo[mat]('name'))
+     *     arma_numpy.mat_to_numpy_X(GetParamWithInfo[mat](p, 'name'))
      */
     std::cout << prefix << "result['" << d.name
         << "'] = arma_numpy.mat_to_numpy_" << GetNumpyTypeChar<arma::mat>()
-        << "(GetParamWithInfo[arma.Mat[double]]('" << d.name << "'))"
+        << "(GetParamWithInfo[arma.Mat[double]](p, '" << d.name << "'))"
         << std::endl;
   }
 }
@@ -167,9 +170,10 @@ void PrintOutputProcessing(
  */
 template<typename T>
 void PrintOutputProcessing(
+    util::Params& params,
     util::ParamData& d,
     const size_t indent,
-    const bool onlyOutput,
+    const bool onlyOutput, 
     const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
     const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
 {
@@ -185,11 +189,11 @@ void PrintOutputProcessing(
      * This gives us code like:
      *
      * result = ModelType()
-     * (<ModelType?> result).modelptr = GetParamPtr[Model]('name')
+     * (<ModelType?> result).modelptr = GetParamPtr[Model](p, 'name')
      */
     std::cout << prefix << "result = " << strippedType << "Type()" << std::endl;
     std::cout << prefix << "(<" << strippedType << "Type?> result).modelptr = "
-        << "GetParamPtr[" << strippedType << "]('" << d.name << "')"
+        << "GetParamPtr[" << strippedType << "](p, '" << d.name << "')"
         << std::endl;
 
     /**
@@ -198,7 +202,7 @@ void PrintOutputProcessing(
      * So we need to loop through all input parameters that have the same type,
      * and double-check.
      */
-    std::map<std::string, util::ParamData>& parameters = IO::Parameters();
+    std::map<std::string, util::ParamData>& parameters = params.Parameters();
     for (auto it = parameters.begin(); it != parameters.end(); ++it)
     {
       // Is it an input parameter of the same type?
@@ -233,12 +237,12 @@ void PrintOutputProcessing(
      * This gives us code like:
      *
      * result['name'] = ModelType()
-     * (<ModelType?> result['name']).modelptr = GetParamPtr[Model]('name'))
+     * (<ModelType?> result['name']).modelptr = GetParamPtr[Model](p, 'name'))
      */
     std::cout << prefix << "result['" << d.name << "'] = " << strippedType
         << "Type()" << std::endl;
     std::cout << prefix << "(<" << strippedType << "Type?> result['" << d.name
-        << "']).modelptr = GetParamPtr[" << strippedType << "]('" << d.name
+        << "']).modelptr = GetParamPtr[" << strippedType << "](p, '" << d.name
         << "')" << std::endl;
 
     /**
@@ -247,7 +251,7 @@ void PrintOutputProcessing(
      * So we need to loop through all input parameters that have the same type,
      * and double-check.
      */
-    std::map<std::string, util::ParamData>& parameters = IO::Parameters();
+    std::map<std::string, util::ParamData>& parameters = params.Parameters();
     for (auto it = parameters.begin(); it != parameters.end(); ++it)
     {
       // Is it an input parameter of the same type?
@@ -286,7 +290,9 @@ void PrintOutputProcessing(
  * data.input is false, and should not be called when data.input is true.  If
  * this is the only output, the results will be different.
  *
- * The input pointer should be a pointer to a std::tuple<size_t, bool> where the
+ * The input pointer should be a pointer to a 
+ * std::tuple<util::Params, std::tuple<size_t, bool>> where the first element is
+ * the parameters of the binding and the second element is a tuple where the
  * first element is the indentation and the second element is a boolean
  * representing whether or not this is the only output parameter.
  *
@@ -299,10 +305,11 @@ void PrintOutputProcessing(util::ParamData& d,
                            const void* input,
                            void* /* output */)
 {
-  std::tuple<size_t, bool>* tuple = (std::tuple<size_t, bool>*) input;
+  typedef std::tuple<util::Params, std::tuple<size_t, bool>> TupleType;
+  TupleType* tuple = (TupleType*) input;
 
-  PrintOutputProcessing<typename std::remove_pointer<T>::type>(d,
-      std::get<0>(*tuple), std::get<1>(*tuple));
+  PrintOutputProcessing<typename std::remove_pointer<T>::type>(std::get<0>(*tuple),
+      d, std::get<0>(std::get<1>(*tuple)), std::get<1>(std::get<1>(*tuple)));
 }
 
 } // namespace python

--- a/src/mlpack/bindings/python/print_output_processing.hpp
+++ b/src/mlpack/bindings/python/print_output_processing.hpp
@@ -173,7 +173,7 @@ void PrintOutputProcessing(
     util::Params& params,
     util::ParamData& d,
     const size_t indent,
-    const bool onlyOutput, 
+    const bool onlyOutput,
     const typename boost::disable_if<arma::is_arma_type<T>>::type* = 0,
     const typename boost::enable_if<data::HasSerialize<T>>::type* = 0)
 {

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -37,9 +37,9 @@ void PrintPYX(const util::BindingDetails& doc,
 {
   std::string functionName = bindingName + "_py";
 
-  util::Params p = IO::Parameters(bindingName);
+  util::Params params = IO::Parameters(bindingName);
 
-  std::map<std::string, util::ParamData>& parameters = p.Parameters();
+  std::map<std::string, util::ParamData>& parameters = params.Parameters();
   typedef std::map<std::string, util::ParamData>::iterator ParamIter;
 
   // Split into input and output parameters.  Take two passes on the input
@@ -110,7 +110,7 @@ void PrintPYX(const util::BindingDetails& doc,
     if (classes.count(d.cppType) == 0)
     {
       const size_t indent = 2;
-      p.functionMap[d.tname]["ImportDecl"](d, (void*) &indent,
+      params.functionMap[d.tname]["ImportDecl"](d, (void*) &indent,
           NULL);
 
       // Make sure we don't double-print the definition.
@@ -125,7 +125,7 @@ void PrintPYX(const util::BindingDetails& doc,
   {
     util::ParamData& d = it->second;
     if (d.input)
-      p.functionMap[d.tname]["PrintClassDefn"](d, NULL, NULL);
+      params.functionMap[d.tname]["PrintClassDefn"](d, NULL, NULL);
   }
 
   // Print the definition.
@@ -137,7 +137,7 @@ void PrintPYX(const util::BindingDetails& doc,
     if (i != 0)
       cout << "," << endl << std::string(indent, ' ');
 
-    p.functionMap[d.tname]["PrintDefn"](d, NULL, NULL);
+    params.functionMap[d.tname]["PrintDefn"](d, NULL, NULL);
   }
 
   // Print closing brace for function definition.
@@ -166,7 +166,7 @@ void PrintPYX(const util::BindingDetails& doc,
 
     cout << "  ";
     size_t indent = 4;
-    p.functionMap[d.tname]["PrintDoc"](d, (void*) &indent,
+    params.functionMap[d.tname]["PrintDoc"](d, (void*) &indent,
         NULL);
     cout << endl;
   }
@@ -179,7 +179,7 @@ void PrintPYX(const util::BindingDetails& doc,
 
     cout << "  ";
     size_t indent = 4;
-    p.functionMap[d.tname]["PrintDoc"](d, (void*) &indent,
+    params.functionMap[d.tname]["PrintDoc"](d, (void*) &indent,
         NULL);
     cout << endl;
   }
@@ -216,7 +216,7 @@ void PrintPYX(const util::BindingDetails& doc,
     util::ParamData& d = parameters.at(inputOptions[i]);
 
     size_t indent = 2;
-    p.functionMap[d.tname]["PrintInputProcessing"](d,
+    params.functionMap[d.tname]["PrintInputProcessing"](d,
         (void*) &indent, NULL);
   }
 
@@ -255,8 +255,8 @@ void PrintPYX(const util::BindingDetails& doc,
     util::ParamData& d = parameters.at(outputOptions[i]);
 
     std::tuple<size_t, bool> t = std::make_tuple(2, false);
-    TupleType tWithParams = std::make_tuple(p, t);
-    p.functionMap[d.tname]["PrintOutputProcessing"](d,
+    TupleType tWithParams = std::make_tuple(params, t);
+    params.functionMap[d.tname]["PrintOutputProcessing"](d,
         (void*) &tWithParams, NULL);
   }
   cout << endl;

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -255,7 +255,7 @@ void PrintPYX(const util::BindingDetails& doc,
     util::ParamData& d = parameters.at(outputOptions[i]);
 
     std::tuple<size_t, bool> t = std::make_tuple(2, false);
-    TupleType tWithParams= std::make_tuple(p, t);
+    TupleType tWithParams = std::make_tuple(p, t);
     p.functionMap[d.tname]["PrintOutputProcessing"](d,
         (void*) &tWithParams, NULL);
   }

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -29,16 +29,17 @@ namespace python {
  * @param doc Documentation for the program.
  * @param mainFilename Filename of the main program (i.e.
  *      "/path/to/pca_main.cpp").
- * @param functionName Name of the function (i.e. "pca").
+ * @param bindingName Name of the binding (i.e. "pca").
  */
 void PrintPYX(const util::BindingDetails& doc,
               const string& mainFilename,
-              const string& functionName)
+              const string& bindingName)
 {
-  // Restore parameters.
-  IO::RestoreSettings(doc.programName);
+  std::string functionName = bindingName + "_py";
 
-  std::map<std::string, util::ParamData>& parameters = IO::Parameters();
+  util::Params p = IO::Parameters(bindingName);
+
+  std::map<std::string, util::ParamData>& parameters = p.Parameters();
   typedef std::map<std::string, util::ParamData>::iterator ParamIter;
 
   // Split into input and output parameters.  Take two passes on the input
@@ -75,6 +76,8 @@ void PrintPYX(const util::BindingDetails& doc,
   cout << "cimport arma" << endl;
   cout << "cimport arma_numpy" << endl;
   cout << "from io cimport IO" << endl;
+  cout << "from params cimport Params" << endl;
+  cout << "from timers cimport Timers" << endl;
   cout << "from io cimport SetParam, SetParamPtr, SetParamWithInfo, "
       << "GetParamPtr" << endl;
   cout << "from io cimport EnableVerbose, DisableVerbose, DisableBacktrace, "
@@ -97,7 +100,7 @@ void PrintPYX(const util::BindingDetails& doc,
 
   // Import the program we will be using.
   cout << "cdef extern from \"<" << mainFilename << ">\" nogil:" << endl;
-  cout << "  cdef void mlpackMain() nogil except +RuntimeError" << endl;
+  cout << "  cdef void " << bindingName << "(Params, Timers)" << " nogil except +RuntimeError" << endl;
   cout << "  " << endl;
   // Print any class definitions we need to have.
   std::set<std::string> classes;
@@ -107,7 +110,7 @@ void PrintPYX(const util::BindingDetails& doc,
     if (classes.count(d.cppType) == 0)
     {
       const size_t indent = 2;
-      IO::GetSingleton().functionMap[d.tname]["ImportDecl"](d, (void*) &indent,
+      p.functionMap[d.tname]["ImportDecl"](d, (void*) &indent,
           NULL);
 
       // Make sure we don't double-print the definition.
@@ -122,7 +125,7 @@ void PrintPYX(const util::BindingDetails& doc,
   {
     util::ParamData& d = it->second;
     if (d.input)
-      IO::GetSingleton().functionMap[d.tname]["PrintClassDefn"](d, NULL, NULL);
+      p.functionMap[d.tname]["PrintClassDefn"](d, NULL, NULL);
   }
 
   // Print the definition.
@@ -131,11 +134,10 @@ void PrintPYX(const util::BindingDetails& doc,
   for (size_t i = 0; i < inputOptions.size(); ++i)
   {
     util::ParamData& d = parameters.at(inputOptions[i]);
-
     if (i != 0)
       cout << "," << endl << std::string(indent, ' ');
 
-    IO::GetSingleton().functionMap[d.tname]["PrintDefn"](d, NULL, NULL);
+    p.functionMap[d.tname]["PrintDefn"](d, NULL, NULL);
   }
 
   // Print closing brace for function definition.
@@ -143,7 +145,7 @@ void PrintPYX(const util::BindingDetails& doc,
 
   // Print the comment describing the function and its parameters.
   cout << "  \"\"\"" << endl;
-  cout << "  " << doc.programName << endl;
+  cout << "  " << doc.name << endl;
   cout << endl;
 
   // Print the description.
@@ -164,7 +166,7 @@ void PrintPYX(const util::BindingDetails& doc,
 
     cout << "  ";
     size_t indent = 4;
-    IO::GetSingleton().functionMap[d.tname]["PrintDoc"](d, (void*) &indent,
+    p.functionMap[d.tname]["PrintDoc"](d, (void*) &indent,
         NULL);
     cout << endl;
   }
@@ -177,7 +179,7 @@ void PrintPYX(const util::BindingDetails& doc,
 
     cout << "  ";
     size_t indent = 4;
-    IO::GetSingleton().functionMap[d.tname]["PrintDoc"](d, (void*) &indent,
+    p.functionMap[d.tname]["PrintDoc"](d, (void*) &indent,
         NULL);
     cout << endl;
   }
@@ -192,16 +194,17 @@ void PrintPYX(const util::BindingDetails& doc,
   cout << "  DisableBacktrace()" << endl;
   cout << "  DisableVerbose()" << endl;
 
-  // Restore the parameters.
-  cout << "  IO.RestoreSettings(\"" << doc.programName << "\")"
+  // Get the Params object from IO.
+  cout << "  cdef Params p = IO.Parameters(\"" << bindingName << "\")"
       << endl;
+  cout << "  cdef Timers t" << endl;
 
   // Determine whether or not we need to copy parameters.
   cout << "  if isinstance(copy_all_inputs, bool):" << endl;
   cout << "    if copy_all_inputs:" << endl;
-  cout << "      SetParam[cbool](<const string> 'copy_all_inputs', "
+  cout << "      SetParam[cbool](p, <const string> 'copy_all_inputs', "
       << "copy_all_inputs)" << endl;
-  cout << "      IO.SetPassed(<const string> 'copy_all_inputs')" << endl;
+  cout << "      p.SetPassed(<const string> 'copy_all_inputs')" << endl;
   cout << "  else:" << endl;
   cout << "    raise TypeError(" <<"\"'copy_all_inputs\' must have type "
       << "\'bool'!\")" << endl;
@@ -213,7 +216,7 @@ void PrintPYX(const util::BindingDetails& doc,
     util::ParamData& d = parameters.at(inputOptions[i]);
 
     size_t indent = 2;
-    IO::GetSingleton().functionMap[d.tname]["PrintInputProcessing"](d,
+    p.functionMap[d.tname]["PrintInputProcessing"](d,
         (void*) &indent, NULL);
   }
 
@@ -222,7 +225,7 @@ void PrintPYX(const util::BindingDetails& doc,
   for (size_t i = 0; i < outputOptions.size(); ++i)
   {
     util::ParamData& d = parameters.at(outputOptions[i]);
-    cout << "  IO.SetPassed(<const string> '" << d.name << "')" << endl;
+    cout << "  p.SetPassed(<const string> '" << d.name << "')" << endl;
   }
 
   // Checking the type of check_input_matrices parameter.
@@ -234,29 +237,28 @@ void PrintPYX(const util::BindingDetails& doc,
   // Before calling mlpackMain(), we check input matrices for NaN values if
   // needed.
   cout << "  if check_input_matrices:" << endl;
-  cout << "    IO.CheckInputMatrices()" << endl;
+  cout << "    p.CheckInputMatrices()" << endl;
 
   // Call the method.
   cout << "  # Call the mlpack program." << endl;
-  cout << "  mlpackMain()" << endl;
+  cout << "  " << bindingName << "(p, t)" << endl;
 
   // Do any output processing and return.
   cout << "  # Initialize result dictionary." << endl;
   cout << "  result = {}" << endl;
   cout << endl;
 
+  typedef std::tuple<util::Params, std::tuple<size_t, bool>> TupleType;
+
   for (size_t i = 0; i < outputOptions.size(); ++i)
   {
     util::ParamData& d = parameters.at(outputOptions[i]);
 
     std::tuple<size_t, bool> t = std::make_tuple(2, false);
-    IO::GetSingleton().functionMap[d.tname]["PrintOutputProcessing"](d,
-        (void*) &t, NULL);
+    TupleType tWithParams= std::make_tuple(p, t);
+    p.functionMap[d.tname]["PrintOutputProcessing"](d,
+        (void*) &tWithParams, NULL);
   }
-
-  // Clear the parameters.
-  cout << endl;
-  cout << "  IO.ClearSettings()" << endl;
   cout << endl;
 
   cout << "  return result" << endl;

--- a/src/mlpack/bindings/python/py_option.hpp
+++ b/src/mlpack/bindings/python/py_option.hpp
@@ -50,7 +50,7 @@ class PyOption
            const bool required = false,
            const bool input = true,
            const bool noTranspose = false,
-           const std::string& /*testName*/ = "")
+           const std::string& bindingName = "")
   {
     // Create the ParamData object to give to IO.
     util::ParamData data;
@@ -76,39 +76,25 @@ class PyOption
     // Every parameter we'll get from Python will have the correct type.
     data.value = boost::any(defaultValue);
 
-    // Restore the parameters for this program.
-    if (identifier != "verbose" && identifier != "copy_all_inputs")
-      IO::RestoreSettings(programName, false);
-
     // Set the function pointers that we'll need.  All of these function
     // pointers will be used by both the program that generates the pyx, and
     // also the binding itself.  (The binding itself will only use GetParam,
     // GetPrintableParam, and GetRawParam.)
-    IO::GetSingleton().functionMap[data.tname]["GetParam"] = &GetParam<T>;
-    IO::GetSingleton().functionMap[data.tname]["GetPrintableParam"] =
-        &GetPrintableParam<T>;
-
-    IO::GetSingleton().functionMap[data.tname]["DefaultParam"] =
-        &DefaultParam<T>;
+    IO::AddFunction(tname, "GetParam", &GetParam<T>);
+    IO::AddFunction(tname, "GetPrintableParam", &GetPrintableParam<T>);
+    IO::AddFunction(tname, "DefaultParam", &DefaultParam<T>);
 
     // These are used by the pyx generator.
-    IO::GetSingleton().functionMap[data.tname]["PrintClassDefn"] =
-        &PrintClassDefn<T>;
-    IO::GetSingleton().functionMap[data.tname]["PrintDefn"] = &PrintDefn<T>;
-    IO::GetSingleton().functionMap[data.tname]["PrintDoc"] = &PrintDoc<T>;
-    IO::GetSingleton().functionMap[data.tname]["PrintOutputProcessing"] =
-        &PrintOutputProcessing<T>;
-    IO::GetSingleton().functionMap[data.tname]["PrintInputProcessing"] =
-        &PrintInputProcessing<T>;
-    IO::GetSingleton().functionMap[data.tname]["ImportDecl"] = &ImportDecl<T>;
+    IO::AddFunction(tname, "PrintClassDefn", &PrintClassDefn<T>);
+    IO::AddFunction(tname, "PrintDefn", &PrintDefn<T>);
+    IO::AddFunction(tname, "PrintDoc", &PrintDoc<T>);
+    IO::AddFunction(tname, "PrintOutputProcessing", &PrintOutputProcessing<T>);
+    IO::AddFunction(tname, "PrintInputProcessing", &PrintInputProcessing<T>);
+    IO::AddFunction(tname, "ImportDecl", &ImportDecl<T>);
 
-    // Add the ParamData object, then store.  This is necessary because we may
-    // import more than one .so that uses IO, so we have to keep the options
-    // separate.  programName is a global variable from mlpack_main.hpp.
-    IO::Add(std::move(data));
-    if (identifier != "verbose" && identifier != "copy_all_inputs")
-      IO::StoreSettings(programName);
-    IO::ClearSettings();
+    // Add the ParamData object to the IO class 
+    // for the correct binding name.
+    IO::AddParameter(bindingName, std::move(data));
   }
 };
 

--- a/src/mlpack/bindings/python/py_option.hpp
+++ b/src/mlpack/bindings/python/py_option.hpp
@@ -60,13 +60,6 @@ class PyOption
     data.required = required;
     data.input = input;
     data.loaded = false;
-    // Only "verbose", "copy_all_inputs" and "check_input_matrices"
-    // will be persistent.
-    if (identifier == "verbose" || identifier == "copy_all_inputs" ||
-        identifier == "check_input_matrices")
-      data.persistent = true;
-    else
-      data.persistent = false;
     data.cppType = cppName;
 
     // Every parameter we'll get from Python will have the correct type.
@@ -88,7 +81,7 @@ class PyOption
     IO::AddFunction(data.tname, "PrintInputProcessing", &PrintInputProcessing<T>);
     IO::AddFunction(data.tname, "ImportDecl", &ImportDecl<T>);
 
-    // Add the ParamData object to the IO class 
+    // Add the ParamData object to the IO class
     // for the correct binding name.
     IO::AddParameter(bindingName, std::move(data));
   }

--- a/src/mlpack/bindings/python/py_option.hpp
+++ b/src/mlpack/bindings/python/py_option.hpp
@@ -27,9 +27,6 @@ namespace mlpack {
 namespace bindings {
 namespace python {
 
-// Defined in mlpack_main.hpp.
-extern std::string programName;
-
 /**
  * The Python option class.
  */
@@ -39,8 +36,7 @@ class PyOption
  public:
   /**
    * Construct a PyOption object.  When constructed, it will register itself
-   * with IO. The testName parameter is not used and added for compatibility
-   * reasons.
+   * with IO.
    */
   PyOption(const T defaultValue,
            const std::string& identifier,
@@ -80,17 +76,17 @@ class PyOption
     // pointers will be used by both the program that generates the pyx, and
     // also the binding itself.  (The binding itself will only use GetParam,
     // GetPrintableParam, and GetRawParam.)
-    IO::AddFunction(tname, "GetParam", &GetParam<T>);
-    IO::AddFunction(tname, "GetPrintableParam", &GetPrintableParam<T>);
-    IO::AddFunction(tname, "DefaultParam", &DefaultParam<T>);
+    IO::AddFunction(data.tname, "GetParam", &GetParam<T>);
+    IO::AddFunction(data.tname, "GetPrintableParam", &GetPrintableParam<T>);
+    IO::AddFunction(data.tname, "DefaultParam", &DefaultParam<T>);
 
     // These are used by the pyx generator.
-    IO::AddFunction(tname, "PrintClassDefn", &PrintClassDefn<T>);
-    IO::AddFunction(tname, "PrintDefn", &PrintDefn<T>);
-    IO::AddFunction(tname, "PrintDoc", &PrintDoc<T>);
-    IO::AddFunction(tname, "PrintOutputProcessing", &PrintOutputProcessing<T>);
-    IO::AddFunction(tname, "PrintInputProcessing", &PrintInputProcessing<T>);
-    IO::AddFunction(tname, "ImportDecl", &ImportDecl<T>);
+    IO::AddFunction(data.tname, "PrintClassDefn", &PrintClassDefn<T>);
+    IO::AddFunction(data.tname, "PrintDefn", &PrintDefn<T>);
+    IO::AddFunction(data.tname, "PrintDoc", &PrintDoc<T>);
+    IO::AddFunction(data.tname, "PrintOutputProcessing", &PrintOutputProcessing<T>);
+    IO::AddFunction(data.tname, "PrintInputProcessing", &PrintInputProcessing<T>);
+    IO::AddFunction(data.tname, "ImportDecl", &ImportDecl<T>);
 
     // Add the ParamData object to the IO class 
     // for the correct binding name.

--- a/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
+++ b/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
@@ -11,6 +11,12 @@
  */
 #include <mlpack/prereqs.hpp>
 #include <mlpack/core/util/io.hpp>
+
+#ifdef BINDING_NAME
+  #undef BINDING_NAME
+#endif
+#define BINDING_NAME python_binding_test
+
 #include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/core/kernels/gaussian_kernel.hpp>
 
@@ -19,7 +25,7 @@ using namespace mlpack;
 using namespace mlpack::kernel;
 
 // Program Name.
-BINDING_NAME("Python binding test");
+BINDING_USER_NAME("Python binding test");
 
 // Short description.
 BINDING_SHORT_DESC(
@@ -73,32 +79,32 @@ PARAM_MODEL_OUT(GaussianKernel, "model_out", "Output model, with twice the "
     "bandwidth.", "");
 PARAM_DOUBLE_OUT("model_bw_out", "The bandwidth of the model.");
 
-static void mlpackMain()
+static void BINDING_NAME(util::Params& params, util::Timers& timer)
 {
-  const string s = IO::GetParam<string>("string_in");
-  const int i = IO::GetParam<int>("int_in");
-  const double d = IO::GetParam<double>("double_in");
+  const string s = params.Get<string>("string_in");
+  const int i = params.Get<int>("int_in");
+  const double d = params.Get<double>("double_in");
 
-  IO::GetParam<string>("string_out") = "wrong";
-  IO::GetParam<int>("int_out") = 11;
-  IO::GetParam<double>("double_out") = 3.0;
+  params.Get<string>("string_out") = "wrong";
+  params.Get<int>("int_out") = 11;
+  params.Get<double>("double_out") = 3.0;
 
   // Check that everything is right on the input, and then set output
   // accordingly.
-  if (!IO::HasParam("flag2") && IO::HasParam("flag1"))
+  if (!params.Has("flag2") && params.Has("flag1"))
   {
     if (s == "hello")
-      IO::GetParam<string>("string_out") = "hello2";
+      params.Get<string>("string_out") = "hello2";
 
     if (i == 12)
-      IO::GetParam<int>("int_out") = 13;
+      params.Get<int>("int_out") = 13;
 
     if (d == 4.0)
-      IO::GetParam<double>("double_out") = 5.0;
+      params.Get<double>("double_out") = 5.0;
   }
 
-  const arma::mat& matReqIn = IO::GetParam<arma::mat>("mat_req_in");
-  const arma::vec& colReqIn = IO::GetParam<arma::vec>("col_req_in");
+  const arma::mat& matReqIn = params.Get<arma::mat>("mat_req_in");
+  const arma::vec& colReqIn = params.Get<arma::vec>("col_req_in");
   if (matReqIn.n_rows != 1 || matReqIn.n_cols != 1 || matReqIn(0, 0) != 1.0)
   {
     throw std::invalid_argument("mat_req_in must be 1x1 and contain only "
@@ -113,103 +119,103 @@ static void mlpackMain()
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and
   // the 3rd row will be multiplied by two.
-  if (IO::HasParam("matrix_in"))
+  if (params.Has("matrix_in"))
   {
-    arma::mat out = move(IO::GetParam<arma::mat>("matrix_in"));
+    arma::mat out = move(params.Get<arma::mat>("matrix_in"));
     out.shed_row(4);
     out.row(2) *= 2.0;
 
-    IO::GetParam<arma::mat>("matrix_out") = move(out);
+    params.Get<arma::mat>("matrix_out") = move(out);
   }
 
   // Input matrices should be at least 5 rows; the 5th row will be dropped and
   // the 3rd row will be multiplied by two.
-  if (IO::HasParam("umatrix_in"))
+  if (params.Has("umatrix_in"))
   {
     arma::Mat<size_t> out =
-        move(IO::GetParam<arma::Mat<size_t>>("umatrix_in"));
+        move(params.Get<arma::Mat<size_t>>("umatrix_in"));
     out.shed_row(4);
     out.row(2) *= 2;
 
-    IO::GetParam<arma::Mat<size_t>>("umatrix_out") = move(out);
+    params.Get<arma::Mat<size_t>>("umatrix_out") = move(out);
   }
 
   // An input matrix (pandas.Series) should have all elements multiplied by two.
-  if (IO::HasParam("smatrix_in"))
+  if (params.Has("smatrix_in"))
   {
-    arma::mat out = move(IO::GetParam<arma::mat>("smatrix_in"));
+    arma::mat out = move(params.Get<arma::mat>("smatrix_in"));
     out *= 2.0;
 
-    IO::GetParam<arma::mat>("smatrix_out") = move(out);
+    params.Get<arma::mat>("smatrix_out") = move(out);
   }
 
   // An input matrix (pandas.Series) should have all elements multiplied by two.
-  if (IO::HasParam("s_umatrix_in"))
+  if (params.Has("s_umatrix_in"))
   {
     arma::Mat<size_t> out =
-        move(IO::GetParam<arma::Mat<size_t>>("s_umatrix_in"));
+        move(params.Get<arma::Mat<size_t>>("s_umatrix_in"));
     out *= 2;
 
-    IO::GetParam<arma::Mat<size_t>>("s_umatrix_out") = move(out);
+    params.Get<arma::Mat<size_t>>("s_umatrix_out") = move(out);
   }
 
   // An input column or row should have all elements multiplied by two.
-  if (IO::HasParam("col_in"))
+  if (params.Has("col_in"))
   {
-    arma::vec out = move(IO::GetParam<arma::vec>("col_in"));
+    arma::vec out = move(params.Get<arma::vec>("col_in"));
     out *= 2.0;
 
-    IO::GetParam<arma::vec>("col_out") = move(out);
+    params.Get<arma::vec>("col_out") = move(out);
   }
 
-  if (IO::HasParam("ucol_in"))
+  if (params.Has("ucol_in"))
   {
     arma::Col<size_t> out =
-        move(IO::GetParam<arma::Col<size_t>>("ucol_in"));
+        move(params.Get<arma::Col<size_t>>("ucol_in"));
     out *= 2;
 
-    IO::GetParam<arma::Col<size_t>>("ucol_out") = move(out);
+    params.Get<arma::Col<size_t>>("ucol_out") = move(out);
   }
 
-  if (IO::HasParam("row_in"))
+  if (params.Has("row_in"))
   {
-    arma::rowvec out = move(IO::GetParam<arma::rowvec>("row_in"));
+    arma::rowvec out = move(params.Get<arma::rowvec>("row_in"));
     out *= 2.0;
 
-    IO::GetParam<arma::rowvec>("row_out") = move(out);
+    params.Get<arma::rowvec>("row_out") = move(out);
   }
 
-  if (IO::HasParam("urow_in"))
+  if (params.Has("urow_in"))
   {
     arma::Row<size_t> out =
-        move(IO::GetParam<arma::Row<size_t>>("urow_in"));
+        move(params.Get<arma::Row<size_t>>("urow_in"));
     out *= 2;
 
-    IO::GetParam<arma::Row<size_t>>("urow_out") = move(out);
+    params.Get<arma::Row<size_t>>("urow_out") = move(out);
   }
 
   // Vector arguments should have the last element removed.
-  if (IO::HasParam("vector_in"))
+  if (params.Has("vector_in"))
   {
-    vector<int> out = move(IO::GetParam<vector<int>>("vector_in"));
+    vector<int> out = move(params.Get<vector<int>>("vector_in"));
     out.pop_back();
 
-    IO::GetParam<vector<int>>("vector_out") = move(out);
+    params.Get<vector<int>>("vector_out") = move(out);
   }
 
-  if (IO::HasParam("str_vector_in"))
+  if (params.Has("str_vector_in"))
   {
-    vector<string> out = move(IO::GetParam<vector<string>>("str_vector_in"));
+    vector<string> out = move(params.Get<vector<string>>("str_vector_in"));
     out.pop_back();
 
-    IO::GetParam<vector<string>>("str_vector_out") = move(out);
+    params.Get<vector<string>>("str_vector_out") = move(out);
   }
 
   // All numeric elements should be multiplied by 3.
-  if (IO::HasParam("matrix_and_info_in"))
+  if (params.Has("matrix_and_info_in"))
   {
     typedef tuple<data::DatasetInfo, arma::mat> TupleType;
-    TupleType tuple = move(IO::GetParam<TupleType>("matrix_and_info_in"));
+    TupleType tuple = move(params.Get<TupleType>("matrix_and_info_in"));
 
     const data::DatasetInfo& di = std::get<0>(tuple);
     arma::mat& m = std::get<1>(tuple);
@@ -220,19 +226,19 @@ static void mlpackMain()
         m.row(i) *= 2.0;
     }
 
-    IO::GetParam<arma::mat>("matrix_and_info_out") = move(m);
+    params.Get<arma::mat>("matrix_and_info_out") = move(m);
   }
 
   // If we got a request to build a model, then build it.
-  if (IO::HasParam("build_model"))
+  if (params.Has("build_model"))
   {
-    IO::GetParam<GaussianKernel*>("model_out") = new GaussianKernel(10.0);
+    params.Get<GaussianKernel*>("model_out") = new GaussianKernel(10.0);
   }
 
   // If we got an input model, double the bandwidth and output that.
-  if (IO::HasParam("model_in"))
+  if (params.Has("model_in"))
   {
-    IO::GetParam<double>("model_bw_out") =
-        IO::GetParam<GaussianKernel*>("model_in")->Bandwidth() * 2.0;
+    params.Get<double>("model_bw_out") =
+        params.Get<GaussianKernel*>("model_in")->Bandwidth() * 2.0;
   }
 }

--- a/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
+++ b/src/mlpack/bindings/python/tests/test_python_binding_main.cpp
@@ -15,7 +15,7 @@
 #ifdef BINDING_NAME
   #undef BINDING_NAME
 #endif
-#define BINDING_NAME python_binding_test
+#define BINDING_NAME test_python_binding
 
 #include <mlpack/core/util/mlpack_main.hpp>
 #include <mlpack/core/kernels/gaussian_kernel.hpp>

--- a/src/mlpack/bindings/tests/test_option.hpp
+++ b/src/mlpack/bindings/tests/test_option.hpp
@@ -82,7 +82,6 @@ class TestOption
     data.loaded = false;
     data.cppType = cppName;
     data.value = boost::any(defaultValue);
-    data.persistent = false;
 
     const std::string tname = data.tname;
 

--- a/src/mlpack/core/util/io.cpp
+++ b/src/mlpack/core/util/io.cpp
@@ -181,9 +181,16 @@ util::Params IO::Parameters(const std::string& bindingName)
 
   std::map<char, std::string> resultAliases =
       GetSingleton().aliases[bindingName];
+  // Merge in any persistent parameters (e.g. parameters in the "" binding map).
+  std::map<char, std::string> persistentAliases = GetSingleton().aliases[""];
+  resultAliases.insert(persistentAliases.begin(), persistentAliases.end());
 
   std::map<std::string, util::ParamData> resultParams =
       GetSingleton().parameters[bindingName];
+  // Merge in any persistent parameters (e.g. parameters in the "" binding map).
+  std::map<std::string, util::ParamData> persistentParams =
+      GetSingleton().parameters[""];
+  resultParams.insert(persistentParams.begin(), persistentParams.end());
 
   return Params(resultAliases, resultParams, GetSingleton().functionMap,
       bindingName, GetSingleton().docs[bindingName]);

--- a/src/mlpack/core/util/io.cpp
+++ b/src/mlpack/core/util/io.cpp
@@ -59,14 +59,13 @@ void IO::AddParameter(const std::string& bindingName, ParamData&& data)
 
   // If found in current map, print fatal error and terminate the program, but
   // only if the parameter is not consistent.
-  if (bindingParams.count(data.name) && !data.persistent)
+  if (bindingParams.count(data.name))
   {
     outstr << "Parameter '" << data.name << "' ('" << data.alias << "') "
            << "is defined multiple times with the same identifiers."
            << std::endl;
   }
-  if (data.alias != '\0' && bindingAliases.count(data.alias) &&
-      !data.persistent)
+  if (data.alias != '\0' && bindingAliases.count(data.alias))
   {
     outstr << "Parameter '" << data.name << " ('" << data.alias << "') "
            << "is defined multiple times with the same alias." << std::endl;
@@ -182,16 +181,9 @@ util::Params IO::Parameters(const std::string& bindingName)
 
   std::map<char, std::string> resultAliases =
       GetSingleton().aliases[bindingName];
-  // Merge in any persistent parameters (e.g. parameters in the "" binding map).
-  std::map<char, std::string> persistentAliases = GetSingleton().aliases[""];
-  resultAliases.insert(persistentAliases.begin(), persistentAliases.end());
 
   std::map<std::string, util::ParamData> resultParams =
       GetSingleton().parameters[bindingName];
-  // Merge in any persistent parameters (e.g. parameters in the "" binding map).
-  std::map<std::string, util::ParamData> persistentParams =
-      GetSingleton().parameters[""];
-  resultParams.insert(persistentParams.begin(), persistentParams.end());
 
   return Params(resultAliases, resultParams, GetSingleton().functionMap,
       bindingName, GetSingleton().docs[bindingName]);

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -220,10 +220,14 @@ using Option = mlpack::bindings::python::PyOption<T>;
 
 #include <mlpack/core/util/param.hpp>
 
+#ifndef BINDING_NAME
+  #error "BINDING_NAME not defined!"
+#endif
 // These parameters should not be registered to any BINDING_NAME,
 // they are registered under "".
 #ifdef BINDING_NAME
-    #undef BINDING_NAME
+  #define OLD_BINDING_NAME BINDING_NAME
+  #undef BINDING_NAME
 #endif
 #define BINDING_NAME
 
@@ -236,7 +240,14 @@ PARAM_FLAG("copy_all_inputs", "If specified, all input parameters will be deep"
 PARAM_FLAG("check_input_matrices", "If specified, the input matrix is checked "
     "for NaN and inf values; an exception is thrown if any are found.", "");
 
-// Nothing else needs to be defined---the binding will use mlpackMain() as-is.
+// redefining BINDING_NAME.
+#ifdef OLD_BINDING_NAME
+  #undef BINDING_NAME
+  #define BINDING_NAME OLD_BINDING_NAME
+  #undef OLD_BINDING_NAME
+#endif
+
+// Nothing else needs to be defined---the binding will use BINDING_NAME() as-is.
 
 #elif(BINDING_TYPE == BINDING_TYPE_JL) // This is a Julia binding.
 

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -224,14 +224,17 @@ using Option = mlpack::bindings::python::PyOption<T>;
   #error "BINDING_NAME not defined!"
 #endif
 
-PARAM_FLAG("verbose", "Display informational messages and the full list of "
-    "parameters and timers at the end of execution.", "v");
-PARAM_FLAG("copy_all_inputs", "If specified, all input parameters will be deep"
-    " copied before the method is run.  This is useful for debugging problems "
-    "where the input parameters are being modified by the algorithm, but can "
-    "slow down the code.", "");
-PARAM_FLAG("check_input_matrices", "If specified, the input matrix is checked "
-    "for NaN and inf values; an exception is thrown if any are found.", "");
+PARAM_GLOBAL(bool, "verbose", "Display informational messages and the full "
+    "list of parameters and timers at the end of execution.", "v", "bool",
+    false, true, false, false)
+PARAM_GLOBAL(bool, "copy_all_inputs", "If specified, all input parameters "
+    "will be deep copied before the method is run.  This is useful for "
+    "debugging problems where the input parameters are being modified "
+    "by the algorithm, but can slow down the code.", "", "bool",
+    false, true, false, false)
+PARAM_GLOBAL(bool, "check_input_matrices", "If specified, the input matrix "
+    "is checked for NaN and inf values; an exception is thrown if any are "
+    "found.", "", "bool", false, true, false, false)
 
 // Nothing else needs to be defined---the binding will use BINDING_NAME() as-is.
 

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -223,13 +223,6 @@ using Option = mlpack::bindings::python::PyOption<T>;
 #ifndef BINDING_NAME
   #error "BINDING_NAME not defined!"
 #endif
-// These parameters should not be registered to any BINDING_NAME,
-// they are registered under "".
-#ifdef BINDING_NAME
-  #define OLD_BINDING_NAME BINDING_NAME
-  #undef BINDING_NAME
-#endif
-#define BINDING_NAME
 
 PARAM_FLAG("verbose", "Display informational messages and the full list of "
     "parameters and timers at the end of execution.", "v");
@@ -239,13 +232,6 @@ PARAM_FLAG("copy_all_inputs", "If specified, all input parameters will be deep"
     "slow down the code.", "");
 PARAM_FLAG("check_input_matrices", "If specified, the input matrix is checked "
     "for NaN and inf values; an exception is thrown if any are found.", "");
-
-// redefining BINDING_NAME.
-#ifdef OLD_BINDING_NAME
-  #undef BINDING_NAME
-  #define BINDING_NAME OLD_BINDING_NAME
-  #undef OLD_BINDING_NAME
-#endif
 
 // Nothing else needs to be defined---the binding will use BINDING_NAME() as-is.
 

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -207,7 +207,7 @@ using Option = mlpack::bindings::tests::TestOption<T>;
  * not a specific parameter check should be ignored.
  */
 #define BINDING_IGNORE_CHECK(x) mlpack::bindings::python::IgnoreCheck( \
-		STRINGIFY(BINDING_NAME), x)
+    STRINGIFY(BINDING_NAME), x)
 
 namespace mlpack {
 namespace util {
@@ -223,7 +223,7 @@ using Option = mlpack::bindings::python::PyOption<T>;
 // These parameters should not be registered to any BINDING_NAME,
 // they are registered under "".
 #ifdef BINDING_NAME
-	#undef BINDING_NAME
+    #undef BINDING_NAME
 #endif
 #define BINDING_NAME
 

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -172,7 +172,8 @@ using Option = mlpack::bindings::tests::TestOption<T>;
  * PRINT_PARAM_STRING() returns a string that contains the correct
  * language-specific representation of a parameter's name.
  */
-#define PRINT_PARAM_STRING mlpack::bindings::python::ParamString
+#define PRINT_PARAM_STRING(x) mlpack::bindings::python::ParamString( \
+    STRINGIFY(BINDING_NAME), x)
 
 /**
  * PRINT_PARAM_VALUE() returns a string that contains a correct
@@ -205,7 +206,8 @@ using Option = mlpack::bindings::tests::TestOption<T>;
  * BINDING_IGNORE_CHECK() is an internally-used macro to determine whether or
  * not a specific parameter check should be ignored.
  */
-#define BINDING_IGNORE_CHECK mlpack::bindings::python::IgnoreCheck
+#define BINDING_IGNORE_CHECK(x) mlpack::bindings::python::IgnoreCheck( \
+		STRINGIFY(BINDING_NAME), x)
 
 namespace mlpack {
 namespace util {
@@ -216,21 +218,14 @@ using Option = mlpack::bindings::python::PyOption<T>;
 }
 }
 
-static const std::string testName = "";
 #include <mlpack/core/util/param.hpp>
 
-// TODO: fix this...
-#undef BINDING_USER_NAME
-#define BINDING_USER_NAME(NAME) static \
-    mlpack::util::ProgramName \
-    io_programname_dummy_object = mlpack::util::ProgramName(NAME); \
-    namespace mlpack { \
-    namespace bindings { \
-    namespace python { \
-    std::string programName = NAME; \
-    } \
-    } \
-    }
+// These parameters should not be registered to any BINDING_NAME,
+// they are registered under "".
+#ifdef BINDING_NAME
+	#undef BINDING_NAME
+#endif
+#define BINDING_NAME
 
 PARAM_FLAG("verbose", "Display informational messages and the full list of "
     "parameters and timers at the end of execution.", "v");

--- a/src/mlpack/core/util/param.hpp
+++ b/src/mlpack/core/util/param.hpp
@@ -1246,9 +1246,9 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
     REQ, IN, TRANS, arma::Row<size_t>());
 
 /**
- * Define the PARAM(), PARAM_MODEL() macro. Don't use this function; 
+ * Define the PARAM(), PARAM_MODEL() macro. Don't use this function;
  * use the other ones above that call it.  Note that we are using the __LINE__
- * macro for naming these actual parameters when __COUNTER__ does not exist, 
+ * macro for naming these actual parameters when __COUNTER__ does not exist,
  * which is a bit of an ugly hack... but this is the preprocessor, after all.
  * We don't have much choice other than ugliness.
  *
@@ -1267,6 +1267,11 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
       JOIN(io_option_dummy_object_in_, __COUNTER__) \
       (DEF, ID, DESC, ALIAS, NAME, REQ, IN, !TRANS, STRINGIFY(BINDING_NAME));
 
+  #define PARAM_GLOBAL(T, ID, DESC,  ALIAS, NAME, REQ, IN, TRANS, DEF) \
+      static mlpack::util::Option<T> \
+      JOIN(io_option_global_dummy_object_in_, __COUNTER__) \
+      (DEF, ID, DESC, ALIAS, NAME, REQ, IN, !TRANS, "");
+
   // There are no uses of required models, so that is not an option to this
   // macro (it would be easy to add).
   #define PARAM_MODEL(TYPE, ID, DESC, ALIAS, REQ, IN) \
@@ -1283,6 +1288,11 @@ using DatasetInfo = DatasetMapper<IncrementPolicy, std::string>;
       static mlpack::util::Option<T> \
       JOIN(JOIN(io_option_dummy_object_in_, __LINE__), opt) \
       (DEF, ID, DESC, ALIAS, NAME, REQ, IN, !TRANS, STRINGIFY(BINDING_NAME));
+
+  #define PARAM_GLOBAL(T, ID, DESC,  ALIAS, NAME, REQ, IN, TRANS, DEF) \
+      static mlpack::util::Option<T> \
+      JOIN(JOIN(io_option_global_dummy_object_in_, __LINE__), opt) \
+      (DEF, ID, DESC, ALIAS, NAME, REQ, IN, !TRANS, "");
 
   #define PARAM_MODEL(TYPE, ID, DESC, ALIAS, REQ, IN) \
       static mlpack::util::Option<TYPE*> \

--- a/src/mlpack/core/util/param_data.hpp
+++ b/src/mlpack/core/util/param_data.hpp
@@ -74,9 +74,6 @@ struct ParamData
   //! If this is an input parameter that needs extra loading, this indicates
   //! whether or not it has been loaded.
   bool loaded;
-  //! If this should be preserved across different settings (i.e. if it should
-  //! exist for every binding), this should be set to true.
-  bool persistent;
   //! The actual value that is held.  If the user has passed a different type,
   //! this may be a tuple containing multiple values.
   boost::any value;

--- a/src/mlpack/core/util/params.cpp
+++ b/src/mlpack/core/util/params.cpp
@@ -25,6 +25,11 @@ Params::Params(const std::map<char, std::string>& aliases,
   // Nothing to do.
 }
 
+Params::Params()
+{
+  // Nothing to do.
+}
+
 /**
  * Return `true` if the specified parameter was given.
  *

--- a/src/mlpack/core/util/params.hpp
+++ b/src/mlpack/core/util/params.hpp
@@ -35,6 +35,11 @@ class Params
          const BindingDetails& doc);
 
   /**
+   * Empty constructor. For wrapping in bindings.
+   */
+  Params();
+
+  /**
    * Return `true` if the specified parameter was given.
    *
    * @param identifier The name of the parameter in question.

--- a/src/mlpack/methods/CMakeLists.txt
+++ b/src/mlpack/methods/CMakeLists.txt
@@ -1,54 +1,54 @@
 # Recurse into each method mlpack provides.
 set(DIRS
   # mvu # Note: this implementation of MVU does not work.  See #189.
-  adaboost
-  amf
-  ann
-  approx_kfn
-  bias_svd
-  bayesian_linear_regression
-  block_krylov_svd
-  cf
-  dbscan
-  decision_tree
-  det
-  emst
-  fastmks
-  gmm
-  hmm
-  hoeffding_trees
-  kde
-  kernel_pca
-  kmeans
-  lars
+  # adaboost
+  # amf
+  # ann
+  # approx_kfn
+  # bias_svd
+  # bayesian_linear_regression
+  # block_krylov_svd
+  # cf
+  # dbscan
+  # decision_tree
+  # det
+  # emst
+  # fastmks
+  # gmm
+  # hmm
+  # hoeffding_trees
+  # kde
+  # kernel_pca
+  # kmeans
+  # lars
   linear_regression
-  linear_svm
-  lmnn
-  local_coordinate_coding
-  logistic_regression
-  lsh
-  matrix_completion
-  mean_shift
-  naive_bayes
-  nca
-  neighbor_search
-  nmf
-  nystroem_method
-  pca
-  perceptron
-  preprocess
-  quic_svd
-  radical
-  random_forest
-  randomized_svd
-  range_search
-  rann
-  regularized_svd
-  reinforcement_learning
-  softmax_regression
-  sparse_autoencoder
-  sparse_coding
-  svdplusplus
+  # linear_svm
+  # lmnn
+  # local_coordinate_coding
+  # logistic_regression
+  # lsh
+  # matrix_completion
+  # mean_shift
+  # naive_bayes
+  # nca
+  # neighbor_search
+  # nmf
+  # nystroem_method
+  # pca
+  # perceptron
+  # preprocess
+  # quic_svd
+  # radical
+  # random_forest
+  # randomized_svd
+  # range_search
+  # rann
+  # regularized_svd
+  # reinforcement_learning
+  # softmax_regression
+  # sparse_autoencoder
+  # sparse_coding
+  # svdplusplus
 )
 
 foreach(dir ${DIRS})

--- a/src/mlpack/methods/linear_regression/linear_regression_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_main.cpp
@@ -19,11 +19,6 @@
 
 #include <mlpack/core/util/mlpack_main.hpp>
 
-#ifdef BINDING_NAME
-  #undef BINDING_NAME
-#endif
-#define BINDING_NAME linear_regression
-
 #include "linear_regression.hpp"
 
 using namespace mlpack;

--- a/src/mlpack/methods/linear_regression/linear_regression_main.cpp
+++ b/src/mlpack/methods/linear_regression/linear_regression_main.cpp
@@ -19,6 +19,11 @@
 
 #include <mlpack/core/util/mlpack_main.hpp>
 
+#ifdef BINDING_NAME
+  #undef BINDING_NAME
+#endif
+#define BINDING_NAME linear_regression
+
 #include "linear_regression.hpp"
 
 using namespace mlpack;


### PR DESCRIPTION
Okay, so I was able to compile and use the `linear_regression.pyx` successfully now. 
The changes are not so different than what @rcurtin has already done for the CLI. Some key changes are:
1) Adding cython wrappers for `Params` and `Timers`.
2) Replacing `IO` with `Params` in the python codebase (I have not yet made changes in the `python/tests` directory)
3) A small yet significant change was to change the name of the python function. So, `linear_regression` is now `linear_regression_py`, this is done to prevent clashing names with the `linear_regression` actually defined in the `linear_regression_main.cpp` file.

Also, please ignore all the commented methods in `CMakeLists.txt`, I did that because I only wanted to build the `linear_regression` program. This will be changed before final merge.