### PR TITLE
removed `_py` from functionName

### DIFF
--- a/src/mlpack/bindings/python/CMakeLists.txt
+++ b/src/mlpack/bindings/python/CMakeLists.txt
@@ -297,7 +297,7 @@ if (BUILD_PYTHON_BINDINGS)
   # Add the convenience import to __init__.py.  Note that this happens during
   # configuration.
   file(APPEND ${CMAKE_BINARY_DIR}/src/mlpack/bindings/python/mlpack/__init__.py
-      "from .${name} import ${name}_py\n")
+      "from .${name} import ${name}\n")
 endif ()
 endmacro ()
 

--- a/src/mlpack/bindings/python/print_pyx.cpp
+++ b/src/mlpack/bindings/python/print_pyx.cpp
@@ -35,7 +35,7 @@ void PrintPYX(const util::BindingDetails& doc,
               const string& mainFilename,
               const string& bindingName)
 {
-  std::string functionName = bindingName + "_py";
+  std::string functionName = bindingName;
 
   util::Params params = IO::Parameters(bindingName);
 

--- a/src/mlpack/core/util/mlpack_main.hpp
+++ b/src/mlpack/core/util/mlpack_main.hpp
@@ -172,8 +172,7 @@ using Option = mlpack::bindings::tests::TestOption<T>;
  * PRINT_PARAM_STRING() returns a string that contains the correct
  * language-specific representation of a parameter's name.
  */
-#define PRINT_PARAM_STRING(x) mlpack::bindings::python::ParamString( \
-    STRINGIFY(BINDING_NAME), x)
+#define PRINT_PARAM_STRING mlpack::bindings::python::ParamString
 
 /**
  * PRINT_PARAM_VALUE() returns a string that contains a correct


### PR DESCRIPTION
I guess we can remove the `_py` that was added because of conflicting names. Internal wrapped functions will have a `mlpack_` prefix.